### PR TITLE
Added RoleAssign service

### DIFF
--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -35,8 +35,16 @@
             <directory>test/Site</directory>
         </testsuite>
 
-        <testsuite name="user">
-            <directory>test/User</directory>
+        <testsuite name="identity">
+            <directory>test/User/Identity</directory>
+        </testsuite>
+
+        <testsuite name="authorization">
+            <directory>test/User/Authorization</directory>
+        </testsuite>
+
+        <testsuite name="authentication">
+            <directory>test/User/Authentication</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Base/Domain/Service/RoleAssignInterface.php
+++ b/src/Base/Domain/Service/RoleAssignInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Base\Domain\Service;
+
+use DateTimeImmutable;
+
+/**
+ * RoleAssignInterface defines the contract for assigning roles to subjects.
+ *
+ * Encapsulate the use case of giving a subject a role, optionally scoped to a tenant and with optional expiry.
+ * It validates that the role exists before creating the assignment, produces a clear
+ * domain exception if it does not, and persists the assignment through the repository.
+ *
+ * Extension developers call this service when their extension needs to bootstrap
+ * default role assignments (e.g. during installation).
+ */
+interface RoleAssignInterface
+{
+	/**
+	 * Assign the role to the given subject.
+	 *
+	 * @param string                 $subjectId the ID of the subject to whom the role is assigned
+	 * @param string                 $roleSlug  the slug of the role to be assigned
+	 * @param null|string            $tenantId  the optional tenant ID for scoping the assignment
+	 * @param null|DateTimeImmutable $expireAt  the optional expiration date and time for the assignment
+	 */
+	public function assign(
+		string $subjectId,
+		string $roleSlug,
+		?string $tenantId = null,
+		?DateTimeImmutable $expireAt = null
+	): void;
+}

--- a/src/User/Authorization/Domain/Exception/DuplicateRoleAssignmentException.php
+++ b/src/User/Authorization/Domain/Exception/DuplicateRoleAssignmentException.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authorization\Domain\Exception;
+
+use DomainException;
+use Webify\Base\Domain\Exception\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Exception thrown when a role assignment already exists.
+ */
+final class DuplicateRoleAssignmentException extends DomainException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to initiate this with a default message.
+	 */
+	public static function forRoleAndSubject(string $roleId, string $subjetId): self
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.authorization',
+				'role_assignment_exists',
+				[
+					'roleId'    => $roleId,
+					'subjectId' => $subjetId,
+				]
+			),
+			sprintf(
+				'Role assignment is already exists for the given role "%s" and subject "%s".',
+				$roleId,
+				$subjetId
+			)
+		);
+	}
+}

--- a/src/User/Authorization/Domain/Guard/DuplicateRoleAssignment.php
+++ b/src/User/Authorization/Domain/Guard/DuplicateRoleAssignment.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authorization\Domain\Guard;
+
+use Webify\User\Authorization\Domain\Exception\DuplicateRoleAssignmentException;
+use Webify\User\Authorization\Domain\Repository\RoleAssignmentRepositoryInterface;
+use Webify\User\Authorization\Domain\ValueObject\{RoleId, SubjectId};
+
+/**
+ * Guard class to prevent duplicate role assignments.
+ */
+final readonly class DuplicateRoleAssignment
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private RoleAssignmentRepositoryInterface $repository
+	) {}
+
+	/**
+	 * Ensures that a role-subject assignment does not already exist.
+	 *
+	 * @param RoleId    $roleId    the identifier for the role
+	 * @param SubjectId $subjectId the identifier for the subject
+	 *
+	 * @throws DuplicateRoleAssignmentException if the role-subject assignment already exists
+	 */
+	public function guard(RoleId $roleId, SubjectId $subjectId): void
+	{
+		if ($this->repository->isExists($roleId, $subjectId)) {
+			throw DuplicateRoleAssignmentException::forRoleAndSubject($roleId->toNative(), $subjectId->toNative());
+		}
+	}
+}

--- a/src/User/Authorization/Domain/Repository/RoleAssignmentRepositoryInterface.php
+++ b/src/User/Authorization/Domain/Repository/RoleAssignmentRepositoryInterface.php
@@ -15,7 +15,7 @@ namespace Webify\User\Authorization\Domain\Repository;
 
 use Webify\User\Authorization\Domain\Entity\RoleAssignment;
 use Webify\User\Authorization\Domain\Exception\RoleAssignmentNotFoundException;
-use Webify\User\Authorization\Domain\ValueObject\RoleAssignmentId;
+use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleId, SubjectId};
 
 /**
  * RoleAssignmentRepositoryInterface defines the contract for a role assignment repository.
@@ -32,6 +32,16 @@ interface RoleAssignmentRepositoryInterface
 	 * @throws RoleAssignmentNotFoundException if the RoleAssignment with the given identifier is not found
 	 */
 	public function getById(RoleAssignmentId $id): RoleAssignment;
+
+	/**
+	 * Checks if a role assignment exists for the given role ID and subject ID.
+	 *
+	 * @param RoleId    $roleId    the ID of the role
+	 * @param SubjectId $subjectId the ID of the subject
+	 *
+	 * @return bool true if a role assignment exists, false otherwise
+	 */
+	public function isExists(RoleId $roleId, SubjectId $subjectId): bool;
 
 	/**
 	 * Persists the given RoleAssignment object to the data store.

--- a/src/User/Authorization/Domain/Repository/RoleRepositoryInterface.php
+++ b/src/User/Authorization/Domain/Repository/RoleRepositoryInterface.php
@@ -15,7 +15,7 @@ namespace Webify\User\Authorization\Domain\Repository;
 
 use Webify\User\Authorization\Domain\Entity\Role;
 use Webify\User\Authorization\Domain\Exception\RoleNotFoundException;
-use Webify\User\Authorization\Domain\ValueObject\RoleId;
+use Webify\User\Authorization\Domain\ValueObject\{RoleId, RoleSlug};
 
 /**
  * RoleRepositoryInterface defines the contract for a role repository.
@@ -28,6 +28,13 @@ interface RoleRepositoryInterface
 	 * @throws RoleNotFoundException if the role with the given ID is not found
 	 */
 	public function getById(RoleId $id): Role;
+
+	/**
+	 * Retrieves a Role entity by its slug.
+	 *
+	 * @throws RoleNotFoundException if the role with the given slug is not found
+	 */
+	public function getBySlug(RoleSlug $slug): Role;
 
 	/**
 	 * Persists the given Role entity to the data store.

--- a/src/User/Authorization/Domain/Service/CheckAccess.php
+++ b/src/User/Authorization/Domain/Service/CheckAccess.php
@@ -18,11 +18,14 @@ use Webify\Base\Domain\Exception\AccessDeniedException;
 use Webify\Base\Domain\Service\{AuthorizationInterface, CheckAccessInterface};
 
 /**
- * CheckAccess is the implementation of the CheckAccessInterface that uses the
+ * CheckAccess is the implementation of the `CheckAccessInterface` that uses the
  * `AuthorizationInterface` to check access permissions.
  */
 final readonly class CheckAccess implements CheckAccessInterface
 {
+	/**
+	 * The constructor.
+	 */
 	public function __construct(
 		private AuthorizationInterface $authorization
 	) {}

--- a/src/User/Authorization/Domain/Service/RoleAssign.php
+++ b/src/User/Authorization/Domain/Service/RoleAssign.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authorization\Domain\Service;
+
+use DateTimeImmutable;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\Service\{RoleAssignInterface, UlidGeneratorInterface};
+use Webify\Base\Domain\ValueObject\DateTime;
+use Webify\User\Authorization\Domain\Entity\{Role, RoleAssignment};
+use Webify\User\Authorization\Domain\Guard\DuplicateRoleAssignment;
+use Webify\User\Authorization\Domain\Repository\{RoleAssignmentRepositoryInterface, RoleRepositoryInterface};
+use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleSlug, SubjectId, TenantId};
+
+/**
+ * RoleAssign service is implements of RoleAssignInterface.
+ */
+final readonly class RoleAssign implements RoleAssignInterface
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private RoleRepositoryInterface $roleRepository,
+		private RoleAssignmentRepositoryInterface $roleAssignmentRepository,
+		private UlidGeneratorInterface $idGenerator,
+		private DuplicateRoleAssignment $duplicateRoleAssignment,
+		private DomainEventPublisherInterface $eventPublisher
+	) {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function assign(
+		string $subjectId,
+		string $roleSlug,
+		?string $tenantId = null,
+		?DateTimeImmutable $expireAt = null
+	): void {
+		$subjectId  = SubjectId::fromString($subjectId);
+		$role       = $this->getRole($roleSlug);
+
+		// Guard against duplicate role assignments
+		$this->duplicateRoleAssignment->guard($role->getId(), $subjectId);
+
+		$tenantId   = null !== $tenantId ? TenantId::fromString($tenantId) : null;
+		$expireAt   = null !== $expireAt ? DateTime::fromNative($expireAt) : null;
+		$assignment = RoleAssignment::assign(
+			RoleAssignmentId::fromString($this->idGenerator->generate()),
+			$role->getId(),
+			$subjectId,
+			$tenantId,
+			$expireAt
+		);
+
+		$this->roleAssignmentRepository->persist($assignment);
+		$this->eventPublisher->publish(...$assignment->getDomainEvents());
+	}
+
+	/**
+	 * Retrieves a Role object based on the provided role slug.
+	 *
+	 * @param string $roleSlug the slug of the role to retrieve
+	 *
+	 * @return Role the Role object corresponding to the given slug
+	 */
+	private function getRole(string $roleSlug): Role
+	{
+		return $this->roleRepository->getBySlug(RoleSlug::fromString($roleSlug));
+	}
+}

--- a/test/User/Authorization/Domain/Guard/DuplicateRoleAssignmentTest.php
+++ b/test/User/Authorization/Domain/Guard/DuplicateRoleAssignmentTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authorization\Domain\Guard;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Authorization\Domain\Exception\DuplicateRoleAssignmentException;
+use Webify\User\Authorization\Domain\Guard\DuplicateRoleAssignment;
+use Webify\User\Authorization\Domain\Repository\RoleAssignmentRepositoryInterface;
+use Webify\User\Authorization\Domain\ValueObject\{RoleId, SubjectId};
+
+/**
+ * DuplicateRoleAssignmentTest tests the functionality of the DuplicateRoleAssignment guard.
+ *
+ * @internal
+ */
+#[CoversClass(DuplicateRoleAssignment::class)]
+#[CoversMethod(DuplicateRoleAssignment::class, 'guard')]
+final class DuplicateRoleAssignmentTest extends TestCase
+{
+	/**
+	 * Tests that the guard passes when no duplicate role assignment exists.
+	 */
+	#[Test]
+	public function testGuardPassesWhenNoDuplicateExists(): void
+	{
+		$roleId     = RoleId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+		$subjectId  = SubjectId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FBW');
+		$repository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$repository->expects($this->once())
+			->method('isExists')
+			->with($roleId, $subjectId)
+			->willReturn(false)
+		;
+
+		$guard = new DuplicateRoleAssignment($repository);
+
+		$guard->guard($roleId, $subjectId);
+	}
+
+	/**
+	 * Tests that the guard throws an exception when a duplicate role assignment exists.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenDuplicateExists(): void
+	{
+		$roleId     = RoleId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+		$subjectId  = SubjectId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FBW');
+		$repository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$repository->expects($this->once())
+			->method('isExists')
+			->with($roleId, $subjectId)
+			->willReturn(true)
+		;
+
+		$guard = new DuplicateRoleAssignment($repository);
+
+		$this->expectException(DuplicateRoleAssignmentException::class);
+		$guard->guard($roleId, $subjectId);
+	}
+}

--- a/test/User/Authorization/Domain/Service/RoleAssignTest.php
+++ b/test/User/Authorization/Domain/Service/RoleAssignTest.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authorization\Domain\Service;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\Service\UlidGeneratorInterface;
+use Webify\User\Authorization\Domain\Collection\PermissionCollection;
+use Webify\User\Authorization\Domain\Entity\Role;
+use Webify\User\Authorization\Domain\Exception\DuplicateRoleAssignmentException;
+use Webify\User\Authorization\Domain\Guard\DuplicateRoleAssignment;
+use Webify\User\Authorization\Domain\Repository\{RoleAssignmentRepositoryInterface, RoleRepositoryInterface};
+use Webify\User\Authorization\Domain\Service\RoleAssign;
+use Webify\User\Authorization\Domain\ValueObject\{RoleId, RoleName, RoleSlug, SubjectId, TenantId};
+
+/**
+ * RoleAssignTest tests the functionality of the RoleAssign service.
+ *
+ * @internal
+ */
+#[CoversClass(RoleAssign::class)]
+#[CoversMethod(RoleAssign::class, 'assign')]
+final class RoleAssignTest extends TestCase
+{
+	/**
+	 * Identifier for the role.
+	 */
+	private RoleId $roleId;
+
+	/**
+	 * Identifier for the subject.
+	 */
+	private SubjectId $subjectId;
+
+	/**
+	 * Identifier for the tenant.
+	 */
+	private TenantId $tenantId;
+
+	/**
+	 * Slug for the role.
+	 */
+	private RoleSlug $roleSlug;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		$this->roleId    = RoleId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+		$this->subjectId = SubjectId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FBW');
+		$this->tenantId  = TenantId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FCX');
+		$this->roleSlug  = RoleSlug::fromString('admin');
+	}
+
+	/**
+	 * Tests that a role can be assigned successfully.
+	 */
+	#[Test]
+	public function testAssignRoleSuccessfully(): void
+	{
+		$role = Role::create(
+			$this->roleId,
+			RoleName::fromString('Admin'),
+			$this->roleSlug,
+			new PermissionCollection()
+		);
+		$roleRepository = $this->createMock(RoleRepositoryInterface::class);
+
+		$roleRepository->method('getBySlug')
+			->willReturn($role)
+		;
+
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->expects($this->once())
+			->method('persist')
+		;
+
+		$idGenerator = $this->createMock(UlidGeneratorInterface::class);
+
+		$idGenerator->method('generate')
+			->willReturn('01ARZ3NDEKTSV4RRFFQ69G5FDY')
+		;
+
+		$duplicateRoleAssignmentRepo = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$duplicateRoleAssignmentRepo->method('isExists')
+			->willReturn(false)
+		;
+
+		$duplicateRoleAssignment = new DuplicateRoleAssignment($duplicateRoleAssignmentRepo);
+		$eventPublisher          = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->once())
+			->method('publish')
+		;
+
+		$service = new RoleAssign(
+			$roleRepository,
+			$roleAssignmentRepository,
+			$idGenerator,
+			$duplicateRoleAssignment,
+			$eventPublisher
+		);
+
+		$service->assign($this->subjectId->toNative(), $this->roleSlug->toNative());
+	}
+
+	/**
+	 * Tests that a role can be assigned with a tenant ID.
+	 */
+	#[Test]
+	public function testAssignRoleWithTenantId(): void
+	{
+		$role = Role::create(
+			$this->roleId,
+			RoleName::fromString('Admin'),
+			$this->roleSlug,
+			new PermissionCollection()
+		);
+		$roleRepository = $this->createMock(RoleRepositoryInterface::class);
+
+		$roleRepository->method('getBySlug')
+			->willReturn($role)
+		;
+
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->expects($this->once())
+			->method('persist')
+		;
+
+		$idGenerator = $this->createMock(UlidGeneratorInterface::class);
+
+		$idGenerator->method('generate')
+			->willReturn('01ARZ3NDEKTSV4RRFFQ69G5FDY')
+		;
+
+		$duplicateRoleAssignmentRepo = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$duplicateRoleAssignmentRepo->method('isExists')
+			->willReturn(false)
+		;
+
+		$duplicateRoleAssignment = new DuplicateRoleAssignment($duplicateRoleAssignmentRepo);
+		$eventPublisher          = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->once())
+			->method('publish')
+		;
+
+		$service = new RoleAssign(
+			$roleRepository,
+			$roleAssignmentRepository,
+			$idGenerator,
+			$duplicateRoleAssignment,
+			$eventPublisher
+		);
+
+		$service->assign(
+			$this->subjectId->toNative(),
+			$this->roleSlug->toNative(),
+			$this->tenantId->toNative()
+		);
+	}
+
+	/**
+	 * Tests that a role can be assigned with an expiration date.
+	 */
+	#[Test]
+	public function testAssignRoleWithExpiresAt(): void
+	{
+		$role = Role::create(
+			$this->roleId,
+			RoleName::fromString('Admin'),
+			$this->roleSlug,
+			new PermissionCollection()
+		);
+		$roleRepository = $this->createMock(RoleRepositoryInterface::class);
+
+		$roleRepository->method('getBySlug')
+			->willReturn($role)
+		;
+
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->expects($this->once())
+			->method('persist')
+		;
+
+		$idGenerator = $this->createMock(UlidGeneratorInterface::class);
+
+		$idGenerator->method('generate')
+			->willReturn('01ARZ3NDEKTSV4RRFFQ69G5FDY')
+		;
+
+		$duplicateRoleAssignmentRepo = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$duplicateRoleAssignmentRepo->method('isExists')
+			->willReturn(false)
+		;
+
+		$duplicateRoleAssignment = new DuplicateRoleAssignment($duplicateRoleAssignmentRepo);
+		$eventPublisher          = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->once())
+			->method('publish')
+		;
+
+		$service = new RoleAssign(
+			$roleRepository,
+			$roleAssignmentRepository,
+			$idGenerator,
+			$duplicateRoleAssignment,
+			$eventPublisher
+		);
+
+		$expireAt = new DateTimeImmutable('+1 hour');
+
+		$service->assign(
+			$this->subjectId->toNative(),
+			$this->roleSlug->toNative(),
+			null,
+			$expireAt
+		);
+	}
+
+	/**
+	 * Tests that duplicate role assigning throws an exception.
+	 */
+	#[Test]
+	public function testDuplicateRoleAssignmentThrowsException(): void
+	{
+		$role = Role::create(
+			$this->roleId,
+			RoleName::fromString('Admin'),
+			$this->roleSlug,
+			new PermissionCollection()
+		);
+		$roleRepository = $this->createMock(RoleRepositoryInterface::class);
+
+		$roleRepository->method('getBySlug')
+			->willReturn($role)
+		;
+
+		$duplicateRoleAssignmentRepo = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$duplicateRoleAssignmentRepo->method('isExists')
+			->willReturn(true)
+		;
+
+		$duplicateRoleAssignment  = new DuplicateRoleAssignment($duplicateRoleAssignmentRepo);
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->expects($this->never())
+			->method('persist')
+		;
+
+		$idGenerator    = $this->createMock(UlidGeneratorInterface::class);
+		$eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->never())
+			->method('publish')
+		;
+
+		$service = new RoleAssign(
+			$roleRepository,
+			$roleAssignmentRepository,
+			$idGenerator,
+			$duplicateRoleAssignment,
+			$eventPublisher
+		);
+
+		$this->expectException(DuplicateRoleAssignmentException::class);
+		$service->assign($this->subjectId->toNative(), $this->roleSlug->toNative());
+	}
+}


### PR DESCRIPTION
- Added RoleAssign service with DuplicateRoleAssignment guard
- Introduced `RoleAssign` class with `RoleAssignInterface` implementation for assigning roles to subjects.
- Added `DuplicateRoleAssignment` guard and corresponding exception to prevent duplicate role assignments.
- Extended `RoleRepositoryInterface` and `RoleAssignmentRepositoryInterface` for new functionalities.
- Updated PHPUnit configuration and added extensive unit tests for `RoleAssign`, guard, and related changes.