### PR TITLE
Added `RevokeRole` service

### DIFF
--- a/src/Base/Domain/Service/Authorization/AssignRoleInterface.php
+++ b/src/Base/Domain/Service/Authorization/AssignRoleInterface.php
@@ -11,21 +11,18 @@
  */
 declare(strict_types=1);
 
-namespace Webify\Base\Domain\Service;
+namespace Webify\Base\Domain\Service\Authorization;
 
 use DateTimeImmutable;
 
 /**
- * RoleAssignInterface defines the contract for assigning roles to subjects.
+ * AssignRoleInterface defines the contract for assigning roles to subjects.
  *
  * Encapsulate the use case of giving a subject a role, optionally scoped to a tenant and with optional expiry.
  * It validates that the role exists before creating the assignment, produces a clear
  * domain exception if it does not, and persists the assignment through the repository.
- *
- * Extension developers call this service when their extension needs to bootstrap
- * default role assignments (e.g. during installation).
  */
-interface RoleAssignInterface
+interface AssignRoleInterface
 {
 	/**
 	 * Assign the role to the given subject.

--- a/src/Base/Domain/Service/Authorization/AuthorizationInterface.php
+++ b/src/Base/Domain/Service/Authorization/AuthorizationInterface.php
@@ -11,7 +11,7 @@
  */
 declare(strict_types=1);
 
-namespace Webify\Base\Domain\Service;
+namespace Webify\Base\Domain\Service\Authorization;
 
 use Webify\Base\Domain\Contract\Authorization\{AuthorizableResourceInterface, AuthorizableSubjectInterface};
 

--- a/src/Base/Domain/Service/Authorization/AuthorizationRuleRegistryInterface.php
+++ b/src/Base/Domain/Service/Authorization/AuthorizationRuleRegistryInterface.php
@@ -11,7 +11,7 @@
  */
 declare(strict_types=1);
 
-namespace Webify\Base\Domain\Service;
+namespace Webify\Base\Domain\Service\Authorization;
 
 use Webify\Base\Domain\Contract\Authorization\{AuthorizableResourceInterface, AuthorizationRuleInterface};
 

--- a/src/Base/Domain/Service/Authorization/CheckAccessInterface.php
+++ b/src/Base/Domain/Service/Authorization/CheckAccessInterface.php
@@ -11,7 +11,7 @@
  */
 declare(strict_types=1);
 
-namespace Webify\Base\Domain\Service;
+namespace Webify\Base\Domain\Service\Authorization;
 
 use Webify\Base\Domain\Contract\Authorization\{AuthorizableResourceInterface, AuthorizableSubjectInterface};
 use Webify\Base\Domain\Exception\AccessDeniedException;

--- a/src/Base/Domain/Service/Authorization/RevokeRoleInterface.php
+++ b/src/Base/Domain/Service/Authorization/RevokeRoleInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Base\Domain\Service\Authorization;
+
+/**
+ * RevokeRoleInterface defines the contract for revoking roles from subjects.
+ *
+ * Encapsulate the use case of removing a role assignment from a subject.
+ * Revocation must be scoped to the same tenant context the assignment was created in — revoking globally
+ * should not affect tenant-scoped assignments and vice versa.
+ * The service is silent if the assignment does not exist (idempotent behaviour), so callers do not need to check first.
+ */
+interface RevokeRoleInterface
+{
+	/**
+	 * Revoke the role from the given subject.
+	 *
+	 * @param string $roleAssignmentId the ID of the role assignment to be revoked
+	 */
+	public function revoke(string $roleAssignmentId): void;
+}

--- a/src/User/Authorization/Domain/Event/RoleRevoked.php
+++ b/src/User/Authorization/Domain/Event/RoleRevoked.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authorization\Domain\Event;
+
+use DateTimeImmutable;
+use Webify\Base\Domain\Event\DomainEventInterface;
+
+/**
+ * Event that is triggered when a role was revoked.
+ */
+final readonly class RoleRevoked implements DomainEventInterface
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		public string $roleAssignmentId,
+		public string $roleId,
+		public string $subjectId,
+		public ?string $tenantId,
+		public ?DateTimeImmutable $expiresAt,
+		private DateTimeImmutable $createdAt
+	) {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function occurredOn(): DateTimeImmutable
+	{
+		return $this->createdAt;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function eventName(): string
+	{
+		return 'user.authorization.role_was_revoked';
+	}
+}

--- a/src/User/Authorization/Domain/Exception/DuplicateRoleAssignmentException.php
+++ b/src/User/Authorization/Domain/Exception/DuplicateRoleAssignmentException.php
@@ -37,7 +37,7 @@ final class DuplicateRoleAssignmentException extends DomainException implements 
 	/**
 	 * Factory method to initiate this with a default message.
 	 */
-	public static function forRoleAndSubject(string $roleId, string $subjetId): self
+	public static function forRoleAndSubject(string $roleId, string $subjetId, ?string $tenantId = null): self
 	{
 		return new self(
 			new ExceptionTranslation(
@@ -46,6 +46,7 @@ final class DuplicateRoleAssignmentException extends DomainException implements 
 				[
 					'roleId'    => $roleId,
 					'subjectId' => $subjetId,
+					'tenantId'  => $tenantId,
 				]
 			),
 			sprintf(

--- a/src/User/Authorization/Domain/Guard/DuplicateRoleAssignment.php
+++ b/src/User/Authorization/Domain/Guard/DuplicateRoleAssignment.php
@@ -15,7 +15,7 @@ namespace Webify\User\Authorization\Domain\Guard;
 
 use Webify\User\Authorization\Domain\Exception\DuplicateRoleAssignmentException;
 use Webify\User\Authorization\Domain\Repository\RoleAssignmentRepositoryInterface;
-use Webify\User\Authorization\Domain\ValueObject\{RoleId, SubjectId};
+use Webify\User\Authorization\Domain\ValueObject\{RoleId, SubjectId, TenantId};
 
 /**
  * Guard class to prevent duplicate role assignments.
@@ -32,15 +32,20 @@ final readonly class DuplicateRoleAssignment
 	/**
 	 * Ensures that a role-subject assignment does not already exist.
 	 *
-	 * @param RoleId    $roleId    the identifier for the role
-	 * @param SubjectId $subjectId the identifier for the subject
+	 * @param RoleId        $roleId    the identifier for the role
+	 * @param SubjectId     $subjectId the identifier for the subject
+	 * @param null|TenantId $tenantId  the identifier for the tenant, if applicable
 	 *
 	 * @throws DuplicateRoleAssignmentException if the role-subject assignment already exists
 	 */
-	public function guard(RoleId $roleId, SubjectId $subjectId): void
+	public function guard(RoleId $roleId, SubjectId $subjectId, ?TenantId $tenantId = null): void
 	{
-		if ($this->repository->isExists($roleId, $subjectId)) {
-			throw DuplicateRoleAssignmentException::forRoleAndSubject($roleId->toNative(), $subjectId->toNative());
+		if ($this->repository->isExists($roleId, $subjectId, $tenantId)) {
+			throw DuplicateRoleAssignmentException::forRoleAndSubject(
+				$roleId->toNative(),
+				$subjectId->toNative(),
+				$tenantId?->toNative()
+			);
 		}
 	}
 }

--- a/src/User/Authorization/Domain/Repository/RoleAssignmentRepositoryInterface.php
+++ b/src/User/Authorization/Domain/Repository/RoleAssignmentRepositoryInterface.php
@@ -15,7 +15,7 @@ namespace Webify\User\Authorization\Domain\Repository;
 
 use Webify\User\Authorization\Domain\Entity\RoleAssignment;
 use Webify\User\Authorization\Domain\Exception\RoleAssignmentNotFoundException;
-use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleId, SubjectId};
+use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleId, SubjectId, TenantId};
 
 /**
  * RoleAssignmentRepositoryInterface defines the contract for a role assignment repository.
@@ -36,12 +36,13 @@ interface RoleAssignmentRepositoryInterface
 	/**
 	 * Checks if a role assignment exists for the given role ID and subject ID.
 	 *
-	 * @param RoleId    $roleId    the ID of the role
-	 * @param SubjectId $subjectId the ID of the subject
+	 * @param RoleId        $roleId    the ID of the role
+	 * @param SubjectId     $subjectId the ID of the subject
+	 * @param null|TenantId $tenantId  the ID of the tenant, if applicable
 	 *
 	 * @return bool true if a role assignment exists, false otherwise
 	 */
-	public function isExists(RoleId $roleId, SubjectId $subjectId): bool;
+	public function isExists(RoleId $roleId, SubjectId $subjectId, ?TenantId $tenantId): bool;
 
 	/**
 	 * Persists the given RoleAssignment object to the data store.
@@ -49,4 +50,11 @@ interface RoleAssignmentRepositoryInterface
 	 * @param RoleAssignment $roleAssignment the RoleAssignment object to be saved
 	 */
 	public function persist(RoleAssignment $roleAssignment): void;
+
+	/**
+	 * Deletes the specified role assignment.
+	 *
+	 * @param RoleAssignment $roleAssignment the role assignment instance to be deleted
+	 */
+	public function delete(RoleAssignment $roleAssignment): void;
 }

--- a/src/User/Authorization/Domain/Service/AssignRole.php
+++ b/src/User/Authorization/Domain/Service/AssignRole.php
@@ -15,7 +15,8 @@ namespace Webify\User\Authorization\Domain\Service;
 
 use DateTimeImmutable;
 use Webify\Base\Domain\Event\DomainEventPublisherInterface;
-use Webify\Base\Domain\Service\{RoleAssignInterface, UlidGeneratorInterface};
+use Webify\Base\Domain\Service\Authorization\AssignRoleInterface;
+use Webify\Base\Domain\Service\UlidGeneratorInterface;
 use Webify\Base\Domain\ValueObject\DateTime;
 use Webify\User\Authorization\Domain\Entity\{Role, RoleAssignment};
 use Webify\User\Authorization\Domain\Guard\DuplicateRoleAssignment;
@@ -23,9 +24,9 @@ use Webify\User\Authorization\Domain\Repository\{RoleAssignmentRepositoryInterfa
 use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleSlug, SubjectId, TenantId};
 
 /**
- * RoleAssign service is implements of RoleAssignInterface.
+ * RoleAssign service class is a concrete implementation of the AssignRoleInterface.
  */
-final readonly class RoleAssign implements RoleAssignInterface
+final readonly class AssignRole implements AssignRoleInterface
 {
 	/**
 	 * The constructor.
@@ -49,11 +50,11 @@ final readonly class RoleAssign implements RoleAssignInterface
 	): void {
 		$subjectId  = SubjectId::fromString($subjectId);
 		$role       = $this->getRole($roleSlug);
+		$tenantId   = null !== $tenantId ? TenantId::fromString($tenantId) : null;
 
 		// Guard against duplicate role assignments
-		$this->duplicateRoleAssignment->guard($role->getId(), $subjectId);
+		$this->duplicateRoleAssignment->guard($role->getId(), $subjectId, $tenantId);
 
-		$tenantId   = null !== $tenantId ? TenantId::fromString($tenantId) : null;
 		$expireAt   = null !== $expireAt ? DateTime::fromNative($expireAt) : null;
 		$assignment = RoleAssignment::assign(
 			RoleAssignmentId::fromString($this->idGenerator->generate()),

--- a/src/User/Authorization/Domain/Service/Authorization.php
+++ b/src/User/Authorization/Domain/Service/Authorization.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Webify\User\Authorization\Domain\Service;
 
 use Webify\Base\Domain\Contract\Authorization\{AuthorizableResourceInterface, AuthorizableSubjectInterface};
-use Webify\Base\Domain\Service\{AuthorizationInterface, AuthorizationRuleRegistryInterface};
+use Webify\Base\Domain\Service\Authorization\{AuthorizationInterface, AuthorizationRuleRegistryInterface};
 use Webify\User\Authorization\Domain\Entity\{Role as RoleEntity, RoleAssignment as RoleAssignmentEntity};
 use Webify\User\Authorization\Domain\Query\{RoleAssignmentQueryInterface, RoleQueryInterface};
 use Webify\User\Authorization\Domain\ReadModel\{Role as RoleReadModel, RoleAssignment as RoleAssignmentReadModel};

--- a/src/User/Authorization/Domain/Service/CheckAccess.php
+++ b/src/User/Authorization/Domain/Service/CheckAccess.php
@@ -15,19 +15,20 @@ namespace Webify\User\Authorization\Domain\Service;
 
 use Webify\Base\Domain\Contract\Authorization\{AuthorizableResourceInterface, AuthorizableSubjectInterface};
 use Webify\Base\Domain\Exception\AccessDeniedException;
-use Webify\Base\Domain\Service\{AuthorizationInterface, CheckAccessInterface};
+use Webify\Base\Domain\Service\{Webify\Base\Domain\Service\Authorization\AuthorizationInterface,
+	Webify\Base\Domain\Service\Authorization\CheckAccessInterface};
 
 /**
  * CheckAccess is the implementation of the `CheckAccessInterface` that uses the
  * `AuthorizationInterface` to check access permissions.
  */
-final readonly class CheckAccess implements CheckAccessInterface
+final readonly class CheckAccess implements \Webify\Base\Domain\Service\Authorization\CheckAccessInterface
 {
 	/**
 	 * The constructor.
 	 */
 	public function __construct(
-		private AuthorizationInterface $authorization
+		private \Webify\Base\Domain\Service\Authorization\AuthorizationInterface $authorization
 	) {}
 
 	/**

--- a/src/User/Authorization/Domain/Service/RevokeRole.php
+++ b/src/User/Authorization/Domain/Service/RevokeRole.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authorization\Domain\Service;
+
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\Service\Authorization\RevokeRoleInterface;
+use Webify\Base\Domain\ValueObject\DateTime;
+use Webify\User\Authorization\Domain\Event\RoleRevoked;
+use Webify\User\Authorization\Domain\Exception\RoleAssignmentNotFoundException;
+use Webify\User\Authorization\Domain\Repository\RoleAssignmentRepositoryInterface;
+use Webify\User\Authorization\Domain\ValueObject\RoleAssignmentId;
+
+/**
+ * RevokeRole service class is a concrete implementation of the RevokeRoleInterface.
+ */
+final readonly class RevokeRole implements RevokeRoleInterface
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private RoleAssignmentRepositoryInterface $roleAssignmentRepository,
+		private DomainEventPublisherInterface $eventPublisher
+	) {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function revoke(string $roleAssignmentId): void
+	{
+		$id = RoleAssignmentId::fromString($roleAssignmentId);
+
+		try {
+			$assignment = $this->roleAssignmentRepository->getById($id);
+
+			$this->roleAssignmentRepository->delete($assignment);
+
+			$this->eventPublisher->publish(
+				new RoleRevoked(
+					$id->toNative(),
+					$assignment->getRoleId()->toNative(),
+					$assignment->getSubjectId()->toNative(),
+					$assignment->getTenantId()?->toNative(),
+					$assignment->getExpiresAt()?->toNative(),
+					DateTime::now()->toNative()
+				)
+			);
+		} catch (RoleAssignmentNotFoundException) {
+			// Silent if the assignment does not exist (idempotent behaviour)
+			return;
+		}
+	}
+}

--- a/test/User/Authorization/Domain/Service/AssignRoleTest.php
+++ b/test/User/Authorization/Domain/Service/AssignRoleTest.php
@@ -23,7 +23,7 @@ use Webify\User\Authorization\Domain\Entity\Role;
 use Webify\User\Authorization\Domain\Exception\DuplicateRoleAssignmentException;
 use Webify\User\Authorization\Domain\Guard\DuplicateRoleAssignment;
 use Webify\User\Authorization\Domain\Repository\{RoleAssignmentRepositoryInterface, RoleRepositoryInterface};
-use Webify\User\Authorization\Domain\Service\RoleAssign;
+use Webify\User\Authorization\Domain\Service\AssignRole;
 use Webify\User\Authorization\Domain\ValueObject\{RoleId, RoleName, RoleSlug, SubjectId, TenantId};
 
 /**
@@ -31,9 +31,9 @@ use Webify\User\Authorization\Domain\ValueObject\{RoleId, RoleName, RoleSlug, Su
  *
  * @internal
  */
-#[CoversClass(RoleAssign::class)]
-#[CoversMethod(RoleAssign::class, 'assign')]
-final class RoleAssignTest extends TestCase
+#[CoversClass(AssignRole::class)]
+#[CoversMethod(AssignRole::class, 'assign')]
+final class AssignRoleTest extends TestCase
 {
 	/**
 	 * Identifier for the role.
@@ -109,7 +109,7 @@ final class RoleAssignTest extends TestCase
 			->method('publish')
 		;
 
-		$service = new RoleAssign(
+		$service = new AssignRole(
 			$roleRepository,
 			$roleAssignmentRepository,
 			$idGenerator,
@@ -163,7 +163,7 @@ final class RoleAssignTest extends TestCase
 			->method('publish')
 		;
 
-		$service = new RoleAssign(
+		$service = new AssignRole(
 			$roleRepository,
 			$roleAssignmentRepository,
 			$idGenerator,
@@ -221,7 +221,7 @@ final class RoleAssignTest extends TestCase
 			->method('publish')
 		;
 
-		$service = new RoleAssign(
+		$service = new AssignRole(
 			$roleRepository,
 			$roleAssignmentRepository,
 			$idGenerator,
@@ -277,7 +277,7 @@ final class RoleAssignTest extends TestCase
 			->method('publish')
 		;
 
-		$service = new RoleAssign(
+		$service = new AssignRole(
 			$roleRepository,
 			$roleAssignmentRepository,
 			$idGenerator,

--- a/test/User/Authorization/Domain/Service/RevokeRoleTest.php
+++ b/test/User/Authorization/Domain/Service/RevokeRoleTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authorization\Domain\Service;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\ValueObject\DateTime;
+use Webify\User\Authorization\Domain\Entity\RoleAssignment;
+use Webify\User\Authorization\Domain\Event\RoleRevoked;
+use Webify\User\Authorization\Domain\Exception\RoleAssignmentNotFoundException;
+use Webify\User\Authorization\Domain\Repository\RoleAssignmentRepositoryInterface;
+use Webify\User\Authorization\Domain\Service\RevokeRole;
+use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleId, SubjectId, TenantId};
+
+/**
+ * RevokeRoleTest tests the functionality of the RevokeRole service.
+ *
+ * @internal
+ */
+#[CoversClass(RevokeRole::class)]
+#[CoversMethod(RevokeRole::class, 'revoke')]
+final class RevokeRoleTest extends TestCase
+{
+	/**
+	 * Identifier for the assignment.
+	 */
+	private RoleAssignmentId $assignmentId;
+
+	/**
+	 * Represents the identifier of a role.
+	 */
+	private RoleId $roleId;
+
+	/**
+	 * Denotes the identifier of a subject.
+	 */
+	private SubjectId $subjectId;
+
+	/**
+	 * Denotes the unique identifier of a tenant.
+	 */
+	private TenantId $tenantId;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		$this->assignmentId = RoleAssignmentId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV');
+		$this->roleId       = RoleId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FBW');
+		$this->subjectId    = SubjectId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FCX');
+		$this->tenantId     = TenantId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FDY');
+	}
+
+	/**
+	 * Tests that a role can be revoked successfully.
+	 */
+	#[Test]
+	public function testRevokeRoleSuccessfully(): void
+	{
+		$assignment               = RoleAssignment::assign($this->assignmentId, $this->roleId, $this->subjectId);
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->method('getById')
+			->willReturn($assignment)
+		;
+		$roleAssignmentRepository->expects($this->once())
+			->method('delete')
+			->with($assignment)
+		;
+
+		$eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->once())
+			->method('publish')
+			->with($this->isInstanceOf(RoleRevoked::class))
+		;
+
+		$service = new RevokeRole($roleAssignmentRepository, $eventPublisher);
+
+		$service->revoke($this->assignmentId->toNative());
+	}
+
+	/**
+	 * Tests that revoking a non-existent role assignment is idempotent.
+	 */
+	#[Test]
+	public function testRevokeNonExistentRoleIsIdempotent(): void
+	{
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->method('getById')
+			->willThrowException(new RoleAssignmentNotFoundException('Role assignment not found'))
+		;
+		$roleAssignmentRepository->expects($this->never())
+			->method('delete')
+		;
+
+		$eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->never())
+			->method('publish')
+		;
+
+		$service = new RevokeRole($roleAssignmentRepository, $eventPublisher);
+
+		$service->revoke($this->assignmentId->toNative());
+	}
+
+	/**
+	 * Tests that a role with tenant ID can be revoked successfully.
+	 */
+	#[Test]
+	public function testRevokeRoleWithTenantId(): void
+	{
+		$assignment               = RoleAssignment::assign(
+			$this->assignmentId,
+			$this->roleId,
+			$this->subjectId,
+			$this->tenantId
+		);
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->method('getById')
+			->willReturn($assignment)
+		;
+		$roleAssignmentRepository->expects($this->once())
+			->method('delete')
+			->with($assignment)
+		;
+
+		$eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->once())
+			->method('publish')
+			->with($this->isInstanceOf(RoleRevoked::class))
+		;
+
+		$service = new RevokeRole($roleAssignmentRepository, $eventPublisher);
+
+		$service->revoke($this->assignmentId->toNative());
+	}
+
+	/**
+	 * Tests that a role with an expiration date can be revoked successfully.
+	 */
+	#[Test]
+	public function testRevokeRoleWithExpiresAt(): void
+	{
+		$expiresAt  = DateTime::fromTimestamp(time() + 3600);
+		$assignment = RoleAssignment::assign(
+			$this->assignmentId,
+			$this->roleId,
+			$this->subjectId,
+			null,
+			$expiresAt
+		);
+		$roleAssignmentRepository = $this->createMock(RoleAssignmentRepositoryInterface::class);
+
+		$roleAssignmentRepository->method('getById')
+			->willReturn($assignment)
+		;
+
+		$roleAssignmentRepository->expects($this->once())
+			->method('delete')
+			->with($assignment)
+		;
+
+		$eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$eventPublisher->expects($this->once())
+			->method('publish')
+			->with($this->isInstanceOf(RoleRevoked::class))
+		;
+
+		$service = new RevokeRole($roleAssignmentRepository, $eventPublisher);
+
+		$service->revoke($this->assignmentId->toNative());
+	}
+}


### PR DESCRIPTION
Refactored Authorization context:
- Moved Authorization service interfaces into the `Authorization` namespace.
- Renamed `RoleAssign` to `AssignRole` and introduced `RevokeRole` service with `RevokeRoleInterface`.
- Updated `DuplicateRoleAssignment` guard to include tenant scoping.
- Added `RoleRevoked` domain event and repository delete method.
- Revised unit tests for `AssignRole` and added coverage for `RevokeRole`.