### PR TITLE
AggregateRoot events are mutable

### DIFF
--- a/src/Base/Domain/Entity/AggregateRoot.php
+++ b/src/Base/Domain/Entity/AggregateRoot.php
@@ -28,14 +28,6 @@ abstract class AggregateRoot
 	private array $domainEvents = [];
 
 	/**
-	 * Record an event.
-	 */
-	public function recordDomainEvent(DomainEventInterface $event): void
-	{
-		$this->domainEvents[] = $event;
-	}
-
-	/**
 	 * Get domain events.
 	 *
 	 * @return DomainEventInterface[]
@@ -56,5 +48,13 @@ abstract class AggregateRoot
 		$this->domainEvents   = [];
 
 		return $events;
+	}
+
+	/**
+	 * Record an event.
+	 */
+	protected function recordDomainEvent(DomainEventInterface $event): void
+	{
+		$this->domainEvents[] = $event;
 	}
 }

--- a/src/User/Authorization/Domain/Service/CheckAccess.php
+++ b/src/User/Authorization/Domain/Service/CheckAccess.php
@@ -15,20 +15,19 @@ namespace Webify\User\Authorization\Domain\Service;
 
 use Webify\Base\Domain\Contract\Authorization\{AuthorizableResourceInterface, AuthorizableSubjectInterface};
 use Webify\Base\Domain\Exception\AccessDeniedException;
-use Webify\Base\Domain\Service\{Webify\Base\Domain\Service\Authorization\AuthorizationInterface,
-	Webify\Base\Domain\Service\Authorization\CheckAccessInterface};
+use Webify\Base\Domain\Service\Authorization\{AuthorizationInterface, CheckAccessInterface};
 
 /**
  * CheckAccess is the implementation of the `CheckAccessInterface` that uses the
  * `AuthorizationInterface` to check access permissions.
  */
-final readonly class CheckAccess implements \Webify\Base\Domain\Service\Authorization\CheckAccessInterface
+final readonly class CheckAccess implements CheckAccessInterface
 {
 	/**
 	 * The constructor.
 	 */
 	public function __construct(
-		private \Webify\Base\Domain\Service\Authorization\AuthorizationInterface $authorization
+		private AuthorizationInterface $authorization
 	) {}
 
 	/**

--- a/test/Base/Domain/Entity/AggregateRootTest.php
+++ b/test/Base/Domain/Entity/AggregateRootTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
 use PHPUnit\Framework\TestCase;
 use Webify\Base\Domain\Entity\AggregateRoot;
 use Webify\Base\Domain\Event\DomainEventInterface;
+use Webify\Test\Base\Domain\Entity\Fixture\TestableAggregateRoot;
 
 /**
  * AggregateRootTest tests the functionality of the AggregateRoot class.
@@ -35,7 +36,7 @@ final class AggregateRootTest extends TestCase
 	#[Test]
 	public function testRecordEvents(): void
 	{
-		$aggregateRoot = new class extends AggregateRoot {};
+		$aggregateRoot = new TestableAggregateRoot();
 
 		$event1 = $this->createStub(DomainEventInterface::class);
 		$event2 = $this->createStub(DomainEventInterface::class);
@@ -56,7 +57,7 @@ final class AggregateRootTest extends TestCase
 	#[Test]
 	public function testReleaseEvents(): void
 	{
-		$aggregateRoot = new class extends AggregateRoot {};
+		$aggregateRoot = new TestableAggregateRoot();
 
 		$event1 = $this->createStub(DomainEventInterface::class);
 		$event2 = $this->createStub(DomainEventInterface::class);
@@ -80,9 +81,8 @@ final class AggregateRootTest extends TestCase
 	#[Test]
 	public function testReleaseEventsReturnsEmptyArrayWhenNoEventsRecorded(): void
 	{
-		$aggregateRoot = new class extends AggregateRoot {};
-
-		$events = $aggregateRoot->releaseDomainEvents();
+		$aggregateRoot = new TestableAggregateRoot();
+		$events        = $aggregateRoot->releaseDomainEvents();
 
 		$this->assertEmpty($events);
 	}

--- a/test/Base/Domain/Entity/Fixture/TestableAggregateRoot.php
+++ b/test/Base/Domain/Entity/Fixture/TestableAggregateRoot.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\Base\Domain\Entity\Fixture;
+
+use Webify\Base\Domain\Entity\AggregateRoot;
+use Webify\Base\Domain\Event\DomainEventInterface;
+
+/**
+ * SampleAggregateRoot is a sample aggregate root for testing purposes.
+ */
+final class TestableAggregateRoot extends AggregateRoot
+{
+	/**
+	 * Records a domain event to the event stream for later handling or persistence.
+	 *
+	 * @param DomainEventInterface $event the domain event to be recorded
+	 */
+	public function recordDomainEvent(DomainEventInterface $event): void
+	{
+		parent::recordDomainEvent($event);
+	}
+}

--- a/test/User/Authorization/Domain/ValueObject/RoleSlugTest.php
+++ b/test/User/Authorization/Domain/ValueObject/RoleSlugTest.php
@@ -34,8 +34,6 @@ final class RoleSlugTest extends TestCase
 {
 	/**
 	 * Tests the creation of a valid RoleSlug instance from a string.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testCreateValidRoleSlugFromString(): void
@@ -48,8 +46,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that the getVendor method correctly returns the vendor part of a role slug.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testGetVendorReturnsVendorPart(): void
@@ -61,8 +57,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that the getSlug method correctly returns the slug part of a role slug.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testGetSlugReturnsSlugPart(): void
@@ -74,8 +68,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that a role slug with multiple hyphens is correctly created and its native representation is returned.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testCreateRoleSlugWithMultipleHyphens(): void
@@ -87,8 +79,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an exception is thrown when creating a role slug without a vendor separator.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testMissingSeparatorThrowsException(): void
@@ -99,8 +89,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an exception is thrown when the vendor part of a role slug is in uppercase.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testUppercaseVendorThrowsException(): void
@@ -111,8 +99,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an exception is thrown when attempting to create a role slug with uppercase characters.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testUppercaseSlugThrowsException(): void
@@ -123,8 +109,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that creating a RoleSlug with a vendor starting with a hyphen throws an InvalidRoleSlugException.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testVendorStartingWithHyphenThrowsException(): void
@@ -135,8 +119,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that creating a role slug starting with a hyphen throws an InvalidRoleSlugException.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testSlugStartingWithHyphenThrowsException(): void
@@ -147,8 +129,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an exception is thrown when the vendor part of a role slug ends with a hyphen.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testVendorEndingWithHyphenThrowsException(): void
@@ -159,8 +139,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an exception is thrown when a role slug ends with a hyphen.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testSlugEndingWithHyphenThrowsException(): void
@@ -171,8 +149,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that attempting to create a role slug with consecutive hyphens in the vendor part throws an exception.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testVendorWithConsecutiveHyphensThrowsException(): void
@@ -183,8 +159,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an exception is thrown when a role slug contains consecutive hyphens.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testSlugWithConsecutiveHyphensThrowsException(): void
@@ -195,8 +169,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that an empty string passed to the fromString method throws an InvalidRoleSlugException.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testEmptyStringThrowsException(): void
@@ -207,8 +179,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that the equals method returns true when comparing two RoleSlug instances with the same value.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testEqualsReturnsTrueForSameValues(): void
@@ -221,8 +191,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that the equals method returns false when comparing role slugs with different vendors.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testEqualsReturnsFalseForDifferentVendors(): void
@@ -235,8 +203,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that the equals method returns false when comparing two role slugs with different values.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testEqualsReturnsFalseForDifferentSlugs(): void
@@ -249,8 +215,6 @@ final class RoleSlugTest extends TestCase
 
 	/**
 	 * Tests that the __toString method correctly returns the string representation of a role slug.
-	 *
-	 * @return void
 	 */
 	#[Test]
 	public function testToStringReturnsStringValue(): void


### PR DESCRIPTION
Refactored AggregateRoot testing and structure:
- Made `recordDomainEvent` method protected in `AggregateRoot`.
- Introduced `TestableAggregateRoot` for improved test reusability in `AggregateRootTest`.
- Removed unnecessary `@return void` doc comments in `RoleSlugTest`.
- Fixed namespace imports and simplified `CheckAccess` constructor.
- Enhanced test and entity structures for better maintainability.