### PR TITLE
Replaced ad-hoc permission string serialization in `RoleCreated` event

### DIFF
--- a/src/User/Authorization/Domain/Entity/Role.php
+++ b/src/User/Authorization/Domain/Entity/Role.php
@@ -155,12 +155,9 @@ final class Role extends AggregateRoot
 				$role->getId()->toNative(),
 				$role->getName()->toNative(),
 				(string) $role->getSlug(),
-				implode(
-					';' . PHP_EOL,
-					array_map(
-						fn (Permission $permission): string => (string) $permission,
-						$role->getPermissions()->toArray()
-					)
+				array_map(
+					static fn (Permission $permission): array => $permission->toNative(),
+					$role->getPermissions()->toArray()
 				),
 				$role->isSystemRole(),
 				DateTime::now()->toNative()

--- a/src/User/Authorization/Domain/Event/RoleCreated.php
+++ b/src/User/Authorization/Domain/Event/RoleCreated.php
@@ -24,10 +24,14 @@ final readonly class RoleCreated implements DomainEventInterface
 	/**
 	 * The constructor.
 	 *
-	 * @param string            $roleId       the role ID
-	 * @param string            $roleName     the role name
-	 * @param string            $roleSlug     the role slug
-	 * @param string            $permissions  the permissions associated with the role
+	 * @param string $roleId   the role ID
+	 * @param string $roleName the role name
+	 * @param string $roleSlug the role slug
+	 * @param array<int, array{
+	 *     scope: string,
+	 *     action: string,
+	 *     resource: string
+	 * }> $permissions  the permissions associated with the role
 	 * @param bool              $isSystemRole whether the role is a system role
 	 * @param DateTimeImmutable $createdAt    the date and time when the role was created
 	 */
@@ -35,7 +39,7 @@ final readonly class RoleCreated implements DomainEventInterface
 		public string $roleId,
 		public string $roleName,
 		public string $roleSlug,
-		public string $permissions,
+		public array $permissions,
 		public bool $isSystemRole,
 		private DateTimeImmutable $createdAt
 	) {}

--- a/src/User/Authorization/Domain/ValueObject/Permission.php
+++ b/src/User/Authorization/Domain/ValueObject/Permission.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Webify\User\Authorization\Domain\ValueObject;
 
+use JsonSerializable;
 use Webify\User\Authorization\Domain\Exception\PermissionValidationException;
 
 /**
@@ -23,7 +24,7 @@ use Webify\User\Authorization\Domain\Exception\PermissionValidationException;
  * can be expressed as a single Permission("*", "*") rather than an exhaustive matrix.
  * The wildcard logic must live inside this value object, so it is never reimplemented across the codebase.
  */
-final readonly class Permission
+final readonly class Permission implements JsonSerializable
 {
 	/**
 	 * Constructs a new instance of the class.
@@ -70,7 +71,11 @@ final readonly class Permission
 	/**
 	 * Converts the current object state into a native array representation.
 	 *
-	 * @return array<string, string> an associative array containing the action and resource
+	 * @return array{
+	 *     scope: string,
+	 *     action: string,
+	 *     resource: string,
+	 * } an associative array containing the action and resource
 	 */
 	public function toNative(): array
 	{
@@ -79,6 +84,20 @@ final readonly class Permission
 			'action'   => $this->action,
 			'resource' => $this->resource,
 		];
+	}
+
+	/**
+	 * Converts the current object into a JSON-serializable format.
+	 *
+	 * @return array{
+	 *      scope: string,
+	 *      action: string,
+	 *      resource: string,
+	 *  } an associative array containing the action and resource
+	 */
+	public function jsonSerialize(): array
+	{
+		return $this->toNative();
 	}
 
 	/**

--- a/test/User/Authorization/Domain/Entity/RoleTest.php
+++ b/test/User/Authorization/Domain/Entity/RoleTest.php
@@ -61,10 +61,50 @@ final class RoleTest extends TestCase
 	#[Test]
 	public function testRoleCreatedEvent(): void
 	{
-		$events = $this->role->getDomainEvents();
+		$events   = $this->role->getDomainEvents();
+		/** @var RoleCreated $event */
+		$event    = $events[0];
 
 		$this->assertCount(1, $events);
-		$this->assertInstanceOf(RoleCreated::class, $events[0]);
+		$this->assertInstanceOf(RoleCreated::class, $event);
+		$this->assertCount(0, $event->permissions);
+	}
+
+	/**
+	 * Tests that role-created event payload can reconstruct permissions.
+	 */
+	#[Test]
+	public function testRoleCreatedEventPermissionsAreReconstructable(): void
+	{
+		$permissions = PermissionCollection::from([
+			Permission::fromNative([
+				'scope'    => 'post',
+				'action'   => 'create',
+				'resource' => 'article',
+			]),
+			Permission::fromNative([
+				'scope'    => 'user',
+				'action'   => 'read',
+				'resource' => 'profile',
+			]),
+		]);
+
+		$role = Role::create(
+			RoleId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV'),
+			RoleName::fromString('Editor'),
+			RoleSlug::fromString('system.editor'),
+			$permissions
+		);
+
+		/** @var RoleCreated $event */
+		$event = $role->getDomainEvents()[0];
+
+		$this->assertCount(2, $event->permissions);
+
+		foreach ($event->permissions as $index => $permissionData) {
+			$reconstructed = Permission::fromNative($permissionData);
+			$this->assertTrue($reconstructed->equals($permissions->get($index)));
+		}
 	}
 
 	/**

--- a/test/User/Authorization/Domain/ValueObject/PermissionTest.php
+++ b/test/User/Authorization/Domain/ValueObject/PermissionTest.php
@@ -29,6 +29,7 @@ use Webify\User\Authorization\Domain\ValueObject\Permission;
 #[CoversMethod(Permission::class, 'toNative')]
 #[CoversMethod(Permission::class, 'wildcard')]
 #[CoversMethod(Permission::class, 'scopedWildcard')]
+#[CoversMethod(Permission::class, 'jsonSerialize')]
 final class PermissionTest extends TestCase
 {
 	/**
@@ -110,6 +111,45 @@ final class PermissionTest extends TestCase
 			'action'   => 'read',
 			'resource' => 'profile',
 		], $permission->toNative());
+	}
+
+	/**
+	 * Tests that jsonSerialize returns the same value as toNative.
+	 */
+	#[Test]
+	public function testJsonSerializeReturnsNativeArray(): void
+	{
+		$permission = Permission::fromNative([
+			'scope'    => 'post',
+			'action'   => 'create',
+			'resource' => 'article',
+		]);
+
+		$this->assertSame($permission->toNative(), $permission->jsonSerialize());
+	}
+
+	/**
+	 * Tests that json_encode produces the expected structured JSON for a Permission.
+	 */
+	#[Test]
+	public function testJsonEncodeProducesStructuredObject(): void
+	{
+		$permission = Permission::fromNative([
+			'scope'    => 'post',
+			'action'   => 'create',
+			'resource' => 'article',
+		]);
+		$encoded = json_encode($permission);
+
+		$this->assertNotFalse($encoded);
+
+		$decoded = json_decode($encoded, true);
+
+		$this->assertIsArray($decoded);
+
+		$this->assertSame('post', $decoded['scope']);
+		$this->assertSame('create', $decoded['action']);
+		$this->assertSame('article', $decoded['resource']);
 	}
 
 	/**


### PR DESCRIPTION
Implemented JSON serialization for `Permission` value object and updated `RoleCreated` domain event:

- Added `jsonSerialize` method to `Permission` implementing `JsonSerializable`.
- Modified `RoleCreated` to include serializable permissions structure.
- Enhanced test coverage for `Permission` and `RoleCreated` JSON handling.