### PR TITLE
Refactored `throwException` method return type to `never`

### DIFF
--- a/src/Base/Domain/ValueObject/AggregateId.php
+++ b/src/Base/Domain/ValueObject/AggregateId.php
@@ -84,7 +84,7 @@ abstract readonly class AggregateId
 	/**
 	 * Throws a domain-specific exception when validation fails.
 	 */
-	abstract protected function throwException(string $value): void;
+	abstract protected function throwException(string $value): never;
 
 	/**
 	 * Validates if the value perfectly matches the ULID specification.

--- a/src/Base/Domain/ValueObject/Slug.php
+++ b/src/Base/Domain/ValueObject/Slug.php
@@ -76,7 +76,7 @@ abstract readonly class Slug
 	/**
 	 * Throws an exception as part of the implementation detail in derived classes.
 	 */
-	abstract protected function throwException(string $value): void;
+	abstract protected function throwException(string $value): never;
 
 	/**
 	 * Validates the value against a predefined format pattern.

--- a/src/User/Authorization/Domain/ValueObject/RoleAssignmentId.php
+++ b/src/User/Authorization/Domain/ValueObject/RoleAssignmentId.php
@@ -26,7 +26,7 @@ final readonly class RoleAssignmentId extends AggregateId
 	 *
 	 * @throws InvalidRoleAssignmentIdException
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw InvalidRoleAssignmentIdException::fromInvalidId($value);
 	}

--- a/src/User/Authorization/Domain/ValueObject/RoleId.php
+++ b/src/User/Authorization/Domain/ValueObject/RoleId.php
@@ -26,7 +26,7 @@ final readonly class RoleId extends AggregateId
 	 *
 	 * @throws InvalidRoleIdException
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw InvalidRoleIdException::forInvalidId($value);
 	}

--- a/src/User/Authorization/Domain/ValueObject/SubjectId.php
+++ b/src/User/Authorization/Domain/ValueObject/SubjectId.php
@@ -26,7 +26,7 @@ final readonly class SubjectId extends AggregateId
 	 *
 	 * @throws InvalidSubjectIdException
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw InvalidSubjectIdException::forInvalidId($value);
 	}

--- a/src/User/Authorization/Domain/ValueObject/TenantId.php
+++ b/src/User/Authorization/Domain/ValueObject/TenantId.php
@@ -26,7 +26,7 @@ final readonly class TenantId extends AggregateId
 	 *
 	 * @throws InvalidTenantIdException
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw InvalidTenantIdException::forInvalidId($value);
 	}

--- a/src/User/Identity/Domain/ValueObject/UserId.php
+++ b/src/User/Identity/Domain/ValueObject/UserId.php
@@ -26,7 +26,7 @@ final readonly class UserId extends AggregateId
 	 *
 	 * @throws InvalidUserIdException
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw InvalidUserIdException::fromInvalidId($value);
 	}

--- a/test/Base/Domain/ValueObject/Fixture/ExampleAggregateId.php
+++ b/test/Base/Domain/ValueObject/Fixture/ExampleAggregateId.php
@@ -28,7 +28,7 @@ final readonly class ExampleAggregateId extends AggregateId
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw new InvalidArgumentException('Invalid aggregate ID: ' . $value);
 	}

--- a/test/Base/Domain/ValueObject/Fixture/ExampleSlug.php
+++ b/test/Base/Domain/ValueObject/Fixture/ExampleSlug.php
@@ -24,7 +24,7 @@ final readonly class ExampleSlug extends Slug
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function throwException(string $value): void
+	protected function throwException(string $value): never
 	{
 		throw new InvalidArgumentException('Invalid example slug: ' . $value);
 	}

--- a/test/User/Authorization/Domain/Entity/RoleTest.php
+++ b/test/User/Authorization/Domain/Entity/RoleTest.php
@@ -62,6 +62,7 @@ final class RoleTest extends TestCase
 	public function testRoleCreatedEvent(): void
 	{
 		$events   = $this->role->getDomainEvents();
+
 		/** @var RoleCreated $event */
 		$event    = $events[0];
 


### PR DESCRIPTION
Refactored `throwException` method return type to `never` for improved type safety and clarity across value objects.