### PR TITLE
Added additional guard when deactivating a user

### DIFF
--- a/src/User/Identity/Domain/Entity/User.php
+++ b/src/User/Identity/Domain/Entity/User.php
@@ -22,7 +22,9 @@ use Webify\User\Identity\Domain\Event\{UserDisplayNameWasChanged,
 	UserWasDeactivated,
 	UserWasRegistered
 };
-use Webify\User\Identity\Domain\Exception\{UserAlreadyActivatedException, UserAlreadyDeactivatedException};
+use Webify\User\Identity\Domain\Exception\{UserAlreadyActivatedException,
+	UserAlreadyDeactivatedException,
+	UserCannotBeDeactivatedException};
 use Webify\User\Identity\Domain\ValueObject\{PasswordHash, UserEmail, UserId, UserStatus};
 
 /**
@@ -133,12 +135,17 @@ final class User extends AggregateRoot
 	/**
 	 * Deactivate the user.
 	 *
-	 * @throws UserAlreadyDeactivatedException if the user is already deactivated
+	 * @throws UserAlreadyDeactivatedException  if the user is already deactivated
+	 * @throws UserCannotBeDeactivatedException if the user is not in activate state
 	 */
 	public function deactivate(): void
 	{
 		if ($this->status->isDeactivated()) {
 			throw UserAlreadyDeactivatedException::create();
+		}
+
+		if (!$this->status->isActive()) {
+			throw UserCannotBeDeactivatedException::create();
 		}
 
 		$this->status    = UserStatus::Deactivated;

--- a/src/User/Identity/Domain/Exception/UserCannotBeDeactivatedException.php
+++ b/src/User/Identity/Domain/Exception/UserCannotBeDeactivatedException.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Exception;
+
+use LogicException;
+use Webify\Base\Domain\Contract\Translation\ExceptionTranslation;
+use Webify\Base\Domain\Contract\Translation\TranslatableExceptionInterface;
+
+/**
+ * Thrown when a user is cannot be deactivated.
+ */
+final class UserCannotBeDeactivatedException extends LogicException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to create a new instance of UserCannotBeDeactivatedException.
+	 */
+	public static function create(): UserCannotBeDeactivatedException
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.identity',
+				'user_cannot_deactivate'
+			),
+			'Unable to deactivate, the user is not in active state.'
+		);
+	}
+}

--- a/test/User/Identity/Domain/Entity/UserTest.php
+++ b/test/User/Identity/Domain/Entity/UserTest.php
@@ -23,7 +23,9 @@ use Webify\User\Identity\Domain\Event\{
 	UserWasDeactivated,
 	UserWasRegistered
 };
-use Webify\User\Identity\Domain\Exception\{UserAlreadyActivatedException, UserAlreadyDeactivatedException};
+use Webify\User\Identity\Domain\Exception\{UserAlreadyActivatedException,
+	UserAlreadyDeactivatedException,
+	UserCannotBeDeactivatedException};
 use Webify\User\Identity\Domain\Service\PasswordHasher;
 use Webify\User\Identity\Domain\ValueObject\{UserEmail, UserId};
 
@@ -117,14 +119,15 @@ final class UserTest extends TestCase
 	#[Test]
 	public function testDeactivateUser(): void
 	{
+		$this->user->activate();
 		$this->user->deactivate();
 
 		$this->assertTrue($this->user->getStatus()->isDeactivated());
 
 		$events = $this->user->getDomainEvents();
 
-		$this->assertCount(2, $events);
-		$this->assertInstanceOf(UserWasDeactivated::class, $events[1]);
+		$this->assertCount(3, $events);
+		$this->assertInstanceOf(UserWasDeactivated::class, $events[2]);
 	}
 
 	/**
@@ -133,8 +136,19 @@ final class UserTest extends TestCase
 	#[Test]
 	public function testDeactivateAlreadyDeactivatedUserThrowsException(): void
 	{
+		$this->user->activate();
 		$this->user->deactivate();
 		$this->expectException(UserAlreadyDeactivatedException::class);
+		$this->user->deactivate();
+	}
+
+	/**
+	 * Tests deactivating a non-active user will throw an exception.
+	 */
+	#[Test]
+	public function testDeactivateNonActiveUserThrowsException(): void
+	{
+		$this->expectException(UserCannotBeDeactivatedException::class);
 		$this->user->deactivate();
 	}
 


### PR DESCRIPTION
Added `UserCannotBeDeactivatedException` and updated `User` entity logic to enforce status checks during deactivation; enhanced test coverage for non-active deactivation scenarios.