### PR TITLE
Enhanced `PasswordHasher` error handling support

### DIFF
--- a/src/Base/Domain/Exception/AccessDeniedException.php
+++ b/src/Base/Domain/Exception/AccessDeniedException.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Webify\Base\Domain\Exception;
 
-use DomainException;
+use RuntimeException;
 use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
 
 /**
  * Exception thrown when an access denied error occurs in the authorization domain.
  */
-final class AccessDeniedException extends DomainException implements TranslatableExceptionInterface
+final class AccessDeniedException extends RuntimeException implements TranslatableExceptionInterface
 {
 	/**
 	 * Private constructor enforces the use of the factory methods to initiate this exception.

--- a/src/Base/Domain/Exception/DateTimeException.php
+++ b/src/Base/Domain/Exception/DateTimeException.php
@@ -47,7 +47,7 @@ final class DateTimeException extends InvalidArgumentException implements Transl
 	 *
 	 * @return static a new instance of `DateTimeException`
 	 */
-	public static function withDefault(int $code = 0, ?Throwable $previous = null): DateTimeException
+	public static function forDefault(int $code = 0, ?Throwable $previous = null): DateTimeException
 	{
 		return new self(
 			new ExceptionTranslation(
@@ -70,7 +70,7 @@ final class DateTimeException extends InvalidArgumentException implements Transl
 	 *
 	 * @return DateTimeException a new instance of DateTimeException
 	 */
-	public static function fromInvalidDatetime(
+	public static function forInvalidDatetime(
 		string $value,
 		int $code = 0,
 		?Throwable $previous = null
@@ -99,7 +99,7 @@ final class DateTimeException extends InvalidArgumentException implements Transl
 	 *
 	 * @return DateTimeException a new instance of DateTimeException
 	 */
-	public static function fromInvalidTimezone(
+	public static function forInvalidTimezone(
 		string $value,
 		int $code = 0,
 		?Throwable $previous = null

--- a/src/Base/Domain/ValueObject/DateTime.php
+++ b/src/Base/Domain/ValueObject/DateTime.php
@@ -56,7 +56,7 @@ final readonly class DateTime
 				)
 			);
 		} catch (DateInvalidTimeZoneException|DateMalformedStringException $throwable) {
-			throw DateTimeException::withDefault(previous: $throwable);
+			throw DateTimeException::forDefault(previous: $throwable);
 		}
 	}
 
@@ -90,9 +90,9 @@ final readonly class DateTime
 				)
 			);
 		} catch (DateInvalidTimeZoneException $throwable) {
-			$exception = DateTimeException::fromInvalidTimezone(value: $timezone, previous: $throwable);
+			$exception = DateTimeException::forInvalidTimezone(value: $timezone, previous: $throwable);
 		} catch (DateMalformedStringException $throwable) {
-			$exception = DateTimeException::fromInvalidDatetime(value: $datetime, previous: $throwable);
+			$exception = DateTimeException::forInvalidDatetime(value: $datetime, previous: $throwable);
 		}
 
 		throw $exception;
@@ -138,7 +138,7 @@ final readonly class DateTime
 				$this->value->setTimezone(new DateTimeZone($timezone))
 			);
 		} catch (DateInvalidTimeZoneException $throwable) {
-			throw DateTimeException::fromInvalidTimezone(value: $timezone, previous: $throwable);
+			throw DateTimeException::forInvalidTimezone(value: $timezone, previous: $throwable);
 		}
 	}
 
@@ -158,7 +158,7 @@ final readonly class DateTime
 
 			return $value->format($format);
 		} catch (DateInvalidTimeZoneException $throwable) {
-			throw DateTimeException::fromInvalidTimezone(value: $timezone, previous: $throwable);
+			throw DateTimeException::forInvalidTimezone(value: $timezone, previous: $throwable);
 		}
 	}
 

--- a/src/User/Authorization/Domain/Exception/InvalidRoleAssignmentIdException.php
+++ b/src/User/Authorization/Domain/Exception/InvalidRoleAssignmentIdException.php
@@ -39,7 +39,7 @@ final class InvalidRoleAssignmentIdException extends InvalidArgumentException im
 	 *
 	 * @param string $value the invalid role assignment id value
 	 */
-	public static function fromInvalidId(string $value): self
+	public static function forInvalidId(string $value): self
 	{
 		return new self(
 			new ExceptionTranslation(

--- a/src/User/Authorization/Domain/Exception/PermissionValidationException.php
+++ b/src/User/Authorization/Domain/Exception/PermissionValidationException.php
@@ -37,7 +37,7 @@ final class PermissionValidationException extends InvalidArgumentException imple
 	/**
 	 * Creates a new instance of PermissionValidationException for invalid permission properties.
 	 */
-	public static function fromInvalidProperties(): PermissionValidationException
+	public static function forInvalidProperties(): PermissionValidationException
 	{
 		return new self(
 			new ExceptionTranslation(

--- a/src/User/Authorization/Domain/Exception/SystemRoleModificationException.php
+++ b/src/User/Authorization/Domain/Exception/SystemRoleModificationException.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Webify\User\Authorization\Domain\Exception;
 
-use RuntimeException;
+use DomainException;
 use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
 
 /**
  * Exception thrown when system roles try to be modified.
  */
-final class SystemRoleModificationException extends RuntimeException implements TranslatableExceptionInterface
+final class SystemRoleModificationException extends DomainException implements TranslatableExceptionInterface
 {
 	/**
 	 * Private constructor enforces the use of the factory methods to initiate this exception.

--- a/src/User/Authorization/Domain/ValueObject/Permission.php
+++ b/src/User/Authorization/Domain/ValueObject/Permission.php
@@ -41,7 +41,7 @@ final readonly class Permission implements JsonSerializable
 		private string $resource,
 	) {
 		if (!$this->isValid()) {
-			throw PermissionValidationException::fromInvalidProperties();
+			throw PermissionValidationException::forInvalidProperties();
 		}
 	}
 

--- a/src/User/Authorization/Domain/ValueObject/RoleAssignmentId.php
+++ b/src/User/Authorization/Domain/ValueObject/RoleAssignmentId.php
@@ -28,6 +28,6 @@ final readonly class RoleAssignmentId extends AggregateId
 	 */
 	protected function throwException(string $value): never
 	{
-		throw InvalidRoleAssignmentIdException::fromInvalidId($value);
+		throw InvalidRoleAssignmentIdException::forInvalidId($value);
 	}
 }

--- a/src/User/Identity/Domain/Exception/FailedToHashPasswordException.php
+++ b/src/User/Identity/Domain/Exception/FailedToHashPasswordException.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webify\User\Identity\Domain\Exception;
 
 use RuntimeException;
+use Throwable;
 use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
 
 /**
@@ -29,22 +30,26 @@ final class FailedToHashPasswordException extends RuntimeException implements Tr
 	 */
 	private function __construct(
 		public readonly ExceptionTranslation $translation,
-		string $message = ''
+		string $message = '',
+		int $code = 0,
+		?Throwable $previous = null
 	) {
-		parent::__construct($message);
+		parent::__construct($message, $code, $previous);
 	}
 
 	/**
 	 * The constructor.
 	 */
-	public static function create(): FailedToHashPasswordException
+	public static function create(Throwable $previous): FailedToHashPasswordException
 	{
 		return new self(
 			new ExceptionTranslation(
 				'user.identity',
 				'failed_to_hash_password'
 			),
-			'Failed to hash password.'
+			'Failed to hash password.',
+			0,
+			$previous
 		);
 	}
 }

--- a/src/User/Identity/Domain/Exception/InvalidPasswordHashException.php
+++ b/src/User/Identity/Domain/Exception/InvalidPasswordHashException.php
@@ -39,7 +39,7 @@ final class InvalidPasswordHashException extends InvalidArgumentException implem
 	 *
 	 * @param string $hash the invalid password hash value
 	 */
-	public static function fromInvalidPasswordHash(string $hash): self
+	public static function forInvalidPasswordHash(string $hash): self
 	{
 		return new self(
 			new ExceptionTranslation(

--- a/src/User/Identity/Domain/Exception/InvalidUserIdException.php
+++ b/src/User/Identity/Domain/Exception/InvalidUserIdException.php
@@ -39,7 +39,7 @@ final class InvalidUserIdException extends InvalidArgumentException implements T
 	 *
 	 * @param string $id the invalid user id value
 	 */
-	public static function fromInvalidId(string $id): self
+	public static function forInvalidId(string $id): self
 	{
 		return new self(
 			new ExceptionTranslation(

--- a/src/User/Identity/Domain/Exception/UserCannotBeDeactivatedException.php
+++ b/src/User/Identity/Domain/Exception/UserCannotBeDeactivatedException.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Webify\User\Identity\Domain\Exception;
 
 use LogicException;
-use Webify\Base\Domain\Contract\Translation\ExceptionTranslation;
-use Webify\Base\Domain\Contract\Translation\TranslatableExceptionInterface;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
 
 /**
  * Thrown when a user is cannot be deactivated.

--- a/src/User/Identity/Domain/Service/PasswordHasher.php
+++ b/src/User/Identity/Domain/Service/PasswordHasher.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Webify\User\Identity\Domain\Service;
 
+use ValueError;
 use Webify\User\Identity\Domain\Exception\FailedToHashPasswordException;
 use Webify\User\Identity\Domain\ValueObject\PasswordHash;
 
@@ -30,13 +31,13 @@ final readonly class PasswordHasher
 	 */
 	public function hash(string $password): PasswordHash
 	{
-		$hash = password_hash($password, PASSWORD_DEFAULT);
-
-		if (empty($hash)) {
-			throw FailedToHashPasswordException::create();
+		try {
+			return PasswordHash::fromHash(
+				password_hash($password, PASSWORD_DEFAULT)
+			);
+		} catch (ValueError $throwable) {
+			throw FailedToHashPasswordException::create($throwable);
 		}
-
-		return PasswordHash::fromHash($hash);
 	}
 
 	/**

--- a/src/User/Identity/Domain/ValueObject/PasswordHash.php
+++ b/src/User/Identity/Domain/ValueObject/PasswordHash.php
@@ -30,7 +30,7 @@ final readonly class PasswordHash
 	private function __construct(private string $value)
 	{
 		if (!$this->isValid()) {
-			throw InvalidPasswordHashException::fromInvalidPasswordHash($this->value);
+			throw InvalidPasswordHashException::forInvalidPasswordHash($this->value);
 		}
 	}
 

--- a/src/User/Identity/Domain/ValueObject/UserId.php
+++ b/src/User/Identity/Domain/ValueObject/UserId.php
@@ -28,6 +28,6 @@ final readonly class UserId extends AggregateId
 	 */
 	protected function throwException(string $value): never
 	{
-		throw InvalidUserIdException::fromInvalidId($value);
+		throw InvalidUserIdException::forInvalidId($value);
 	}
 }


### PR DESCRIPTION
Enhanced `PasswordHasher` error handling support and Refactored exceptions:

- Enhanced `PasswordHasher` error handling with `ValueError` support.
- Renamed factory methods to use `for*` instead of `from*`.
- Adjusted exception parent classes for better alignment with domain semantics.