### PR TITLE
Added test coverage for `reconstitute` method

### DIFF
--- a/test/User/Authorization/Domain/Entity/RoleAssignmentTest.php
+++ b/test/User/Authorization/Domain/Entity/RoleAssignmentTest.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Webify\Test\User\Authorization\Domain\Entity;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
 use PHPUnit\Framework\TestCase;
 use Webify\Base\Domain\ValueObject\DateTime;
 use Webify\User\Authorization\Domain\Entity\RoleAssignment;
 use Webify\User\Authorization\Domain\Event\RoleAssigned;
+use Webify\User\Authorization\Domain\ReadModel\RoleAssignment as RoleAssignmentReadModel;
 use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleId, SubjectId, TenantId};
 
 /**
@@ -34,6 +36,7 @@ use Webify\User\Authorization\Domain\ValueObject\{RoleAssignmentId, RoleId, Subj
 #[CoversMethod(RoleAssignment::class, 'getExpiresAt')]
 #[CoversMethod(RoleAssignment::class, 'isApplicableFor')]
 #[CoversMethod(RoleAssignment::class, 'isExpired')]
+#[CoversMethod(RoleAssignment::class, 'reconstitute')]
 final class RoleAssignmentTest extends TestCase
 {
 	/**
@@ -90,7 +93,6 @@ final class RoleAssignmentTest extends TestCase
 	public function testAssignWithTenantId(): void
 	{
 		$assignment = RoleAssignment::assign($this->assignmentId, $this->roleId, $this->subjectId, $this->tenantId);
-
 		/** @var TenantId $tenantId */
 		$tenantId = $assignment->getTenantId();
 
@@ -207,9 +209,107 @@ final class RoleAssignmentTest extends TestCase
 	public function testAssignRecordsDomainEvent(): void
 	{
 		$assignment = RoleAssignment::assign($this->assignmentId, $this->roleId, $this->subjectId, $this->tenantId);
-
 		$events = $assignment->getDomainEvents();
+
 		$this->assertCount(1, $events);
 		$this->assertInstanceOf(RoleAssigned::class, $events[0]);
+	}
+
+	/**
+	 * Tests reconstitute restores a RoleAssignment without tenant or expiry.
+	 */
+	#[Test]
+	public function testReconstituteWithoutTenantOrExpiry(): void
+	{
+		$readModel = new RoleAssignmentReadModel(
+			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+			roleId: '01ARZ3NDEKTSV4RRFFQ69G5FBW',
+			subjectId: '01ARZ3NDEKTSV4RRFFQ69G5FCX'
+		);
+		$assignment = RoleAssignment::reconstitute($readModel);
+
+		$this->assertTrue($this->assignmentId->equals($assignment->getId()));
+		$this->assertTrue($this->roleId->equals($assignment->getRoleId()));
+		$this->assertTrue($this->subjectId->equals($assignment->getSubjectId()));
+		$this->assertNull($assignment->getTenantId());
+		$this->assertNull($assignment->getExpiresAt());
+		$this->assertFalse($assignment->isExpired());
+		$this->assertTrue($assignment->isApplicableFor(null));
+		$this->assertCount(0, $assignment->getDomainEvents());
+	}
+
+	/**
+	 * Tests reconstitute restores a RoleAssignment with a tenant but without expiry.
+	 */
+	#[Test]
+	public function testReconstituteWithTenantWithoutExpiry(): void
+	{
+		$readModel = new RoleAssignmentReadModel(
+			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+			roleId: '01ARZ3NDEKTSV4RRFFQ69G5FBW',
+			subjectId: '01ARZ3NDEKTSV4RRFFQ69G5FCX',
+			tenantId: '01ARZ3NDEKTSV4RRFFQ69G5FDY'
+		);
+		$assignment = RoleAssignment::reconstitute($readModel);
+
+		$this->assertTrue($this->assignmentId->equals($assignment->getId()));
+		$this->assertTrue($this->roleId->equals($assignment->getRoleId()));
+		$this->assertTrue($this->subjectId->equals($assignment->getSubjectId()));
+		$this->assertNotNull($assignment->getTenantId());
+		$this->assertTrue($this->tenantId->equals($assignment->getTenantId()));
+		$this->assertNull($assignment->getExpiresAt());
+		$this->assertFalse($assignment->isExpired());
+		$this->assertTrue($assignment->isApplicableFor($this->tenantId));
+		$this->assertFalse($assignment->isApplicableFor(null));
+		$this->assertCount(0, $assignment->getDomainEvents());
+	}
+
+	/**
+	 * Tests reconstitute restores a RoleAssignment with tenant and expiry.
+	 */
+	#[Test]
+	public function testReconstituteWithTenantAndExpiry(): void
+	{
+		$expiresAt = new DateTimeImmutable('+1 hour');
+		$readModel = new RoleAssignmentReadModel(
+			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+			roleId: '01ARZ3NDEKTSV4RRFFQ69G5FBW',
+			subjectId: '01ARZ3NDEKTSV4RRFFQ69G5FCX',
+			tenantId: '01ARZ3NDEKTSV4RRFFQ69G5FDY',
+			expiresAt: $expiresAt
+		);
+		$assignment = RoleAssignment::reconstitute($readModel);
+		/** @var TenantId $tenantId */
+		$tenantId = $assignment->getTenantId();
+
+		$this->assertTrue($this->assignmentId->equals($assignment->getId()));
+		$this->assertTrue($this->roleId->equals($assignment->getRoleId()));
+		$this->assertTrue($this->subjectId->equals($assignment->getSubjectId()));
+		$this->assertTrue($this->tenantId->equals($tenantId));
+		$this->assertNotNull($assignment->getExpiresAt());
+		$this->assertFalse($assignment->isExpired());
+		$this->assertTrue($assignment->isApplicableFor($this->tenantId));
+		$this->assertCount(0, $assignment->getDomainEvents());
+	}
+
+	/**
+	 * Tests reconstitute restores a RoleAssignment with an expired date.
+	 */
+	#[Test]
+	public function testReconstituteWithExpiredDate(): void
+	{
+		$expiresAt = new DateTimeImmutable('-1 hour');
+		$readModel = new RoleAssignmentReadModel(
+			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+			roleId: '01ARZ3NDEKTSV4RRFFQ69G5FBW',
+			subjectId: '01ARZ3NDEKTSV4RRFFQ69G5FCX',
+			tenantId: '01ARZ3NDEKTSV4RRFFQ69G5FDY',
+			expiresAt: $expiresAt
+		);
+		$assignment = RoleAssignment::reconstitute($readModel);
+
+		$this->assertNotNull($assignment->getExpiresAt());
+		$this->assertTrue($assignment->isExpired());
+		$this->assertCount(0, $assignment->getDomainEvents());
 	}
 }

--- a/test/User/Authorization/Domain/Entity/RoleTest.php
+++ b/test/User/Authorization/Domain/Entity/RoleTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Webify\User\Authorization\Domain\Collection\PermissionCollection;
 use Webify\User\Authorization\Domain\Entity\Role;
 use Webify\User\Authorization\Domain\Event\{PermissionGranted, PermissionRevoked, RoleCreated};
+use Webify\User\Authorization\Domain\ReadModel\Role as RoleReadModel;
 use Webify\User\Authorization\Domain\ValueObject\{Permission, RoleId, RoleName, RoleSlug};
 
 /**
@@ -35,6 +36,7 @@ use Webify\User\Authorization\Domain\ValueObject\{Permission, RoleId, RoleName, 
 #[CoversMethod(Role::class, 'revoke')]
 #[CoversMethod(Role::class, 'allows')]
 #[CoversMethod(Role::class, 'create')]
+#[CoversMethod(Role::class, 'reconstitute')]
 final class RoleTest extends TestCase
 {
 	/**
@@ -214,5 +216,43 @@ final class RoleTest extends TestCase
 
 		$this->role->grant($permission);
 		$this->assertFalse($this->role->allows('user', 'delete', 'profile'));
+	}
+
+	/**
+	 * Tests reconstitute returns a valid Role from a read model.
+	 */
+	#[Test]
+	public function testReconstituteFromReadModel(): void
+	{
+		$permissions = PermissionCollection::from([
+			Permission::fromNative([
+				'scope'    => 'post',
+				'action'   => 'create',
+				'resource' => 'article',
+			]),
+			Permission::fromNative([
+				'scope'    => 'user',
+				'action'   => 'read',
+				'resource' => 'profile',
+			]),
+		]);
+		$readModel = new RoleReadModel(
+			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+			name: 'Editor',
+			slug: 'system.editor',
+			permissions: $permissions,
+			isSystemRole: true
+		);
+		$role = Role::reconstitute($readModel);
+
+		$this->assertSame('01ARZ3NDEKTSV4RRFFQ69G5FAV', $role->getId()->toNative());
+		$this->assertSame('Editor', $role->getName()->toNative());
+		$this->assertSame(['vendor' => 'system', 'slug' => 'editor'], $role->getSlug()->toNative());
+		$this->assertCount(2, $role->getPermissions());
+		$this->assertTrue($role->isSystemRole());
+		$this->assertTrue($role->allows('post', 'create', 'article'));
+		$this->assertTrue($role->allows('user', 'read', 'profile'));
+		$this->assertFalse($role->allows('post', 'delete', 'article'));
+		$this->assertCount(0, $role->getDomainEvents());
 	}
 }


### PR DESCRIPTION
Added test coverage for `reconstitute` method in `RoleAssignment` and `Role` entities, verifying restoration from read models under various scenarios, including expired and non-expired states.