### PR TITLE
Added `AccessToken` value object

### DIFF
--- a/src/User/Authentication/Domain/Exception/InvalidAccessTokenException.php
+++ b/src/User/Authentication/Domain/Exception/InvalidAccessTokenException.php
@@ -17,9 +17,9 @@ use InvalidArgumentException;
 use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
 
 /**
- * Exception thrown when an invalid token ID is encountered.
+ * Exception thrown when an invalid access token is encountered.
  */
-final class InvalidTokenIdException extends InvalidArgumentException implements TranslatableExceptionInterface
+final class InvalidAccessTokenException extends InvalidArgumentException implements TranslatableExceptionInterface
 {
 	/**
 	 * Private constructor enforces the use of the factory methods to initiate this exception.
@@ -37,15 +37,15 @@ final class InvalidTokenIdException extends InvalidArgumentException implements 
 	/**
 	 * Factory method to initiate this with a default message.
 	 */
-	public static function forInvalidId(string $id): InvalidTokenIdException
+	public static function forInvalidAccessToken(string $token): InvalidAccessTokenException
 	{
 		return new self(
 			new ExceptionTranslation(
 				'user.authentication',
-				'invalid_token_id',
-				['id' => $id]
+				'invalid_access_token',
+				['token' => $token]
 			),
-			sprintf('The token ID "%s" is invalid.', $id)
+			sprintf('The access token "%s" is invalid.', $token)
 		);
 	}
 }

--- a/src/User/Authentication/Domain/ValueObject/AccessToken.php
+++ b/src/User/Authentication/Domain/ValueObject/AccessToken.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\ValueObject;
+
+use Webify\User\Authentication\Domain\Exception\InvalidAccessTokenException;
+
+/**
+ * Access token value object.
+ *
+ * Represent an opaque, cryptographically random bearer token string handed to a client.
+ * The value object wraps the raw token string and enforces a minimum entropy constraint
+ * (length ≥ 64 characters) so weak tokens can never be persisted.
+ */
+final readonly class AccessToken
+{
+	/**
+	 * Minimum length of the access token.
+	 */
+	private const int MIN_LENGTH = 64;
+
+	/**
+	 * Private constructor enforces the use of the factory method.
+	 *
+	 * @throws InvalidAccessTokenException if the provided value is invalid
+	 */
+	private function __construct(
+		private string $value
+	) {
+		if (!$this->isValid()) {
+			throw InvalidAccessTokenException::forInvalidAccessToken($this->value);
+		}
+	}
+
+	/**
+	 * Converts the object to its string representation.
+	 */
+	public function __toString(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Get the native string value of the access token.
+	 */
+	public function toNative(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Equality check based on the value.
+	 */
+	public function equals(self $other): bool
+	{
+		return $this->toNative() === $other->toNative();
+	}
+
+	/**
+	 * Creates a new cryptographically random access token.
+	 *
+	 * Uses random_bytes() and bin2hex() to produce a 64-character hex token.
+	 */
+	public static function generate(): AccessToken
+	{
+		return new self(bin2hex(random_bytes(32)));
+	}
+
+	/**
+	 * Factory method to create a new instance from a string.
+	 */
+	public static function fromString(string $value): AccessToken
+	{
+		return new self($value);
+	}
+
+	/**
+	 * Checks if the current value meets the minimum length requirement.
+	 *
+	 * @return bool returns true if the value is valid, otherwise false
+	 */
+	private function isValid(): bool
+	{
+		if (strlen($this->value) < self::MIN_LENGTH) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/test/User/Authentication/Domain/ValueObject/AccessTokenTest.php
+++ b/test/User/Authentication/Domain/ValueObject/AccessTokenTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authentication\Domain\ValueObject;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Authentication\Domain\Exception\InvalidAccessTokenException;
+use Webify\User\Authentication\Domain\ValueObject\AccessToken;
+
+/**
+ * Tests for the AccessToken value object.
+ *
+ * @internal
+ */
+#[CoversClass(AccessToken::class)]
+#[CoversMethod(AccessToken::class, 'fromString')]
+#[CoversMethod(AccessToken::class, 'generate')]
+#[CoversMethod(AccessToken::class, 'toNative')]
+#[CoversMethod(AccessToken::class, 'equals')]
+#[CoversMethod(AccessToken::class, '__toString')]
+final class AccessTokenTest extends TestCase
+{
+	/**
+	 * Test can create from a valid 64-character hex string.
+	 */
+	#[Test]
+	public function testFromStringWithValidToken(): void
+	{
+		$value = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+		$token = AccessToken::fromString($value);
+
+		$this->assertSame($value, $token->toNative());
+	}
+
+	/**
+	 * Test throws exception for token shorter than 64 characters.
+	 */
+	#[Test]
+	public function testThrowsExceptionForTooShortToken(): void
+	{
+		$this->expectException(InvalidAccessTokenException::class);
+		$this->expectExceptionMessage('The access token "short" is invalid.');
+
+		AccessToken::fromString('short');
+	}
+
+	/**
+	 * Test generate always produces a 64+ character token.
+	 */
+	#[Test]
+	public function testGenerateProducesLongEnoughToken(): void
+	{
+		$token = AccessToken::generate();
+
+		$this->assertGreaterThanOrEqual(64, strlen($token->toNative()));
+	}
+
+	/**
+	 * Test generate produces a hex string.
+	 */
+	#[Test]
+	public function testGeneratedTokenIsHex(): void
+	{
+		$token = AccessToken::generate();
+
+		$this->assertMatchesRegularExpression('/^[a-f0-9]+$/', $token->toNative());
+	}
+
+	/**
+	 * Test-generated tokens are unique across calls.
+	 */
+	#[Test]
+	public function testGenerateProducesUniqueTokens(): void
+	{
+		$token1 = AccessToken::generate();
+		$token2 = AccessToken::generate();
+
+		$this->assertNotSame($token1->toNative(), $token2->toNative());
+	}
+
+	/**
+	 * Test equals returns true for identical values.
+	 */
+	#[Test]
+	public function testEqualsReturnsTrueForSameValue(): void
+	{
+		$value  = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+		$token1 = AccessToken::fromString($value);
+		$token2 = AccessToken::fromString($value);
+
+		$this->assertTrue($token1->equals($token2));
+	}
+
+	/**
+	 * Test equals returns false for different values.
+	 */
+	#[Test]
+	public function testEqualsReturnsFalseForDifferentValues(): void
+	{
+		$token1 = AccessToken::generate();
+		$token2 = AccessToken::generate();
+
+		$this->assertFalse($token1->equals($token2));
+	}
+
+	/**
+	 * Test __toString returns the token value.
+	 */
+	#[Test]
+	public function testToStringReturnsTokenValue(): void
+	{
+		$value = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+		$token = AccessToken::fromString($value);
+
+		$this->assertSame($value, (string) $token);
+	}
+}


### PR DESCRIPTION
Added `AccessToken` value object and associated `InvalidAccessTokenException` with test coverage. Refactored `InvalidTokenIdException::forInvalidId` return type for consistency.