### PR TITLE
Added `RefreshSession` domain service

### DIFF
--- a/src/User/Authentication/Domain/Service/CreateSession.php
+++ b/src/User/Authentication/Domain/Service/CreateSession.php
@@ -29,7 +29,7 @@ use Webify\User\Authentication\Domain\Repository\SessionRepositoryInterface;
 use Webify\User\Authentication\Domain\ValueObject\{AccessToken, RefreshToken, SessionId, UserId};
 
 /**
- * CreateSession service handles the creation of a new session.
+ * CreateSession domain service handles the creation of a new session.
  *
  * Encapsulate the use case of authenticating a user with email and password and issuing a new
  * session. This is the primary entry point into the Authentication BC.
@@ -56,8 +56,6 @@ final readonly class CreateSession
 	 * @param string            $password  the password provided for authentication
 	 * @param DateTimeImmutable $expiresAt the expiration time for the session
 	 *
-	 * @return Session the newly created session instance
-	 *
 	 * @throws InvalidUserCredentialException            if the email or password is invalid
 	 * @throws UserNotEligibleForAuthenticationException if the user's status does not allow session creation
 	 */
@@ -65,7 +63,7 @@ final readonly class CreateSession
 		string $email,
 		string $password,
 		DateTimeImmutable $expiresAt
-	): Session {
+	): void {
 		$credential = $this->credentialLookup->findByEmail($email);
 
 		if (null === $credential) {
@@ -89,7 +87,5 @@ final readonly class CreateSession
 
 		$this->repository->persist($session);
 		$this->eventPublisher->publish(...$session->getDomainEvents());
-
-		return $session;
 	}
 }

--- a/src/User/Authentication/Domain/Service/RefreshSession.php
+++ b/src/User/Authentication/Domain/Service/RefreshSession.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\Service;
+
+use DateTimeImmutable;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\ValueObject\DateTime;
+use Webify\User\Authentication\Domain\Repository\SessionRepositoryInterface;
+use Webify\User\Authentication\Domain\ValueObject\{AccessToken, RefreshToken};
+
+/**
+ * RefreshSession domain service handles the refreshing of the session.
+ *
+ * Encapsulate the use case of exchanging a valid RefreshToken for a new token pair, extending
+ * the session. The old tokens are invalidated atomically by replacing them inside the same
+ * AuthSession aggregate.
+ */
+final readonly class RefreshSession
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private SessionRepositoryInterface $repository,
+		private DomainEventPublisherInterface $eventPublisher
+	) {}
+
+	/**
+	 * Refreshes the session by generating a new access token and refresh token, then updates the session
+	 * with the provided expiration date.
+	 *
+	 * @param string            $token     the refresh token used to identify the session
+	 * @param DateTimeImmutable $expiresAt the new expiration date for the session
+	 */
+	public function refresh(string $token, DateTimeImmutable $expiresAt): void
+	{
+		// If session is not found, throw an exception itself
+		$session = $this->repository->getByRefreshToken(RefreshToken::fromString($token));
+
+		// If the session is expired or revoked, throw an exception itself
+		$session->refresh(AccessToken::generate(), RefreshToken::generate(), DateTime::fromNative($expiresAt));
+		$this->repository->persist($session);
+		$this->eventPublisher->publish(...$session->getDomainEvents());
+	}
+}

--- a/test/User/Authentication/Domain/Service/CreateSessionTest.php
+++ b/test/User/Authentication/Domain/Service/CreateSessionTest.php
@@ -26,7 +26,7 @@ use Webify\User\Authentication\Domain\Exception\{InvalidUserCredentialException,
 use Webify\User\Authentication\Domain\Guard\UserMustBeActive;
 use Webify\User\Authentication\Domain\Repository\SessionRepositoryInterface;
 use Webify\User\Authentication\Domain\Service\{CreateSession, UserStatusTranslator};
-use Webify\User\Authentication\Domain\ValueObject\UserId;
+use Webify\User\Authentication\Domain\ValueObject\{SessionId, UserId};
 
 /**
  * CreateSessionTest tests the CreateSession domain service.
@@ -100,13 +100,12 @@ final class CreateSessionTest extends TestCase
 	 * - Publishing a domain event for the created session.
 	 *
 	 * It asserts that:
-	 * - The returned session is an instance of the Session class.
-	 * - The session contains the correct user ID corresponding to the provided credentials.
+	 * - The session persisted to the repository contains the correct user ID and session ID.
 	 */
 	#[Test]
 	public function testCreateSessionSuccessfully(): void
 	{
-		$email        = 'test@example.com';
+		$email        = 'test@webifycms.com';
 		$password     = 'password123';
 		$expiresAt    = new DateTimeImmutable('2099-01-01 00:00:00');
 		$userId       = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
@@ -139,17 +138,21 @@ final class CreateSessionTest extends TestCase
 		$this->repository
 			->expects($this->once())
 			->method('persist')
-			->with($this->isInstanceOf(Session::class))
+			->with($this->callback(
+				function (Session $session) use ($userId, $generatedId): bool {
+					$this->assertTrue($session->getUserId()->equals(UserId::fromString($userId)));
+					$this->assertTrue($session->getId()->equals(SessionId::fromString($generatedId)));
+
+					return true;
+				}
+			))
 		;
 		$this->eventPublisher
 			->expects($this->once())
 			->method('publish')
 		;
 
-		$session = $this->createSession->create($email, $password, $expiresAt);
-
-		$this->assertInstanceOf(Session::class, $session);
-		$this->assertTrue($session->getUserId()->equals(UserId::fromString($userId)));
+		$this->createSession->create($email, $password, $expiresAt);
 	}
 
 	/**
@@ -162,12 +165,12 @@ final class CreateSessionTest extends TestCase
 		$this->credentialLookup
 			->expects($this->once())
 			->method('findByEmail')
-			->with('unknown@example.com')
+			->with('unknown@webifycms.com')
 			->willReturn(null)
 		;
 		$this->expectException(InvalidUserCredentialException::class);
 		$this->createSession->create(
-			'unknown@example.com',
+			'unknown@webifycms.com',
 			'any_password',
 			new DateTimeImmutable('2099-01-01 00:00:00')
 		);
@@ -185,7 +188,7 @@ final class CreateSessionTest extends TestCase
 	#[AllowMockObjectsWithoutExpectations]
 	public function testCreateThrowsExceptionWhenPasswordIsInvalid(): void
 	{
-		$email        = 'test@example.com';
+		$email        = 'test@webifycms.com';
 		$passwordHash = password_hash('correct_password', PASSWORD_DEFAULT);
 		$credential   = new UserCredential(
 			id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
@@ -222,7 +225,7 @@ final class CreateSessionTest extends TestCase
 	#[AllowMockObjectsWithoutExpectations]
 	public function testCreateThrowsExceptionWhenUserNotActive(): void
 	{
-		$email        = 'test@example.com';
+		$email        = 'test@webifycms.com';
 		$password     = 'password123';
 		$passwordHash = password_hash($password, PASSWORD_DEFAULT);
 		$credential   = new UserCredential(

--- a/test/User/Authentication/Domain/Service/RefreshSessionTest.php
+++ b/test/User/Authentication/Domain/Service/RefreshSessionTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authentication\Domain\Service;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\{AllowMockObjectsWithoutExpectations, CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\ValueObject\DateTime;
+use Webify\User\Authentication\Domain\Entity\Session;
+use Webify\User\Authentication\Domain\Exception\{CannotRefreshSessionException, SessionNotFoundException};
+use Webify\User\Authentication\Domain\Repository\SessionRepositoryInterface;
+use Webify\User\Authentication\Domain\Service\RefreshSession;
+use Webify\User\Authentication\Domain\ValueObject\{AccessToken, RefreshToken, SessionId, UserId};
+
+/**
+ * RefreshSessionTest tests the RefreshSession domain service.
+ *
+ * @internal
+ */
+#[CoversClass(RefreshSession::class)]
+#[CoversMethod(RefreshSession::class, 'refresh')]
+final class RefreshSessionTest extends TestCase
+{
+	/**
+	 * Repository instance.
+	 */
+	private MockObject&SessionRepositoryInterface $repository;
+
+	/**
+	 * Domain event publisher service instance.
+	 */
+	private DomainEventPublisherInterface&MockObject $eventPublisher;
+
+	/**
+	 * The RefreshSession instance.
+	 */
+	private RefreshSession $refreshSession;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		$this->repository     = $this->createMock(SessionRepositoryInterface::class);
+		$this->eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$this->refreshSession = new RefreshSession(
+			$this->repository,
+			$this->eventPublisher
+		);
+	}
+
+	/**
+	 * Tests that the session is successfully refreshed when a valid refresh token is provided.
+	 *
+	 * This method verifies that the refresh process is executed correctly by:
+	 * - Fetching the session using the provided refresh token.
+	 * - Invoking the refresh method on the session to rotate tokens and extend expiry.
+	 * - Persisting the updated session in the repository.
+	 * - Publishing the domain event for the refreshed session.
+	 *
+	 * It asserts that:
+	 * - The session's access and refresh tokens are rotated after the refresh.
+	 * - The session's expiration date is updated to the new expiry.
+	 * - The repository persist method is called with the updated session.
+	 */
+	#[Test]
+	public function testRefreshSessionSuccessfully(): void
+	{
+		$token          = '4500ccbd09e402fe83717c67dd156512837bfc3fd244125c430260ddd8816266';
+		$expiresAt      = new DateTimeImmutable('2099-01-01 00:00:00');
+		$originalAccess = AccessToken::generate();
+		$session        = Session::open(
+			SessionId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV'),
+			UserId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAW'),
+			$originalAccess,
+			RefreshToken::fromString($token),
+			DateTime::fromString('2099-06-01 00:00:00')
+		);
+
+		$this->repository
+			->expects($this->once())
+			->method('getByRefreshToken')
+			->with($this->isInstanceOf(RefreshToken::class))
+			->willReturn($session)
+		;
+		$this->repository
+			->expects($this->once())
+			->method('persist')
+			->with($session)
+		;
+		$this->eventPublisher
+			->expects($this->once())
+			->method('publish')
+		;
+
+		$this->refreshSession->refresh($token, $expiresAt);
+
+		$this->assertFalse($originalAccess->equals($session->getAccessToken()));
+		$this->assertTrue($session->getExpiresAt()->equals(DateTime::fromNative($expiresAt)));
+	}
+
+	/**
+	 * Tests that the refresh method throws a SessionNotFoundException when the refresh token is not recognized.
+	 */
+	#[Test]
+	#[AllowMockObjectsWithoutExpectations]
+	public function testRefreshThrowsExceptionWhenTokenNotFound(): void
+	{
+		$token = '4500ccbd09e402fe83717c67dd156512837bfc3fd244125c430260ddd8816266';
+
+		$this->repository
+			->expects($this->once())
+			->method('getByRefreshToken')
+			->with($this->isInstanceOf(RefreshToken::class))
+			->willThrowException(SessionNotFoundException::forRefreshToken($token))
+		;
+		$this->expectException(SessionNotFoundException::class);
+		$this->refreshSession->refresh($token, new DateTimeImmutable('2099-01-01 00:00:00'));
+	}
+
+	/**
+	 * Tests that the refresh method throws a CannotRefreshSessionException when the session
+	 * is expired or has been revoked.
+	 */
+	#[Test]
+	#[AllowMockObjectsWithoutExpectations]
+	public function testRefreshThrowsExceptionWhenSessionCannotBeRefreshed(): void
+	{
+		$token   = '4500ccbd09e402fe83717c67dd156512837bfc3fd244125c430260ddd8816266';
+		$session = Session::open(
+			SessionId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV'),
+			UserId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAW'),
+			AccessToken::generate(),
+			RefreshToken::fromString($token),
+			DateTime::fromString('2020-01-01 00:00:00')
+		);
+
+		$this->repository
+			->expects($this->once())
+			->method('getByRefreshToken')
+			->with($this->isInstanceOf(RefreshToken::class))
+			->willReturn($session)
+		;
+		$this->expectException(CannotRefreshSessionException::class);
+		$this->refreshSession->refresh($token, new DateTimeImmutable('2099-01-01 00:00:00'));
+	}
+}


### PR DESCRIPTION
Added `RefreshSession` domain service with tests for session token rotation and expiration handling. Updated `CreateSession` to remove return value and enhanced test coverage with detailed assertions.