### PR TITLE
Implement user registration

### DIFF
--- a/src/User/Identity/Domain/Entity/User.php
+++ b/src/User/Identity/Domain/Entity/User.php
@@ -25,7 +25,7 @@ use Webify\User\Identity\Domain\Event\{UserDisplayNameWasChanged,
 use Webify\User\Identity\Domain\Exception\{UserAlreadyActivatedException,
 	UserAlreadyDeactivatedException,
 	UserCannotBeDeactivatedException};
-use Webify\User\Identity\Domain\ValueObject\{PasswordHash, UserEmail, UserId, UserStatus};
+use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId, UserStatus};
 
 /**
  * User aggregate root.
@@ -38,7 +38,7 @@ final class User extends AggregateRoot
 	 * @param UserId       $id           the unique identifier for the user
 	 * @param UserEmail    $email        the email address of the user
 	 * @param PasswordHash $passwordHash the hashed password of the user
-	 * @param string       $displayName  the display name of the user
+	 * @param DisplayName  $displayName  the display name of the user
 	 * @param DateTime     $createdAt    the datetime when the user was created
 	 * @param DateTime     $updatedAt    the datetime when the user was last updated
 	 * @param UserStatus   $status       the status indicating the user state
@@ -47,7 +47,7 @@ final class User extends AggregateRoot
 		private readonly UserId $id,
 		private UserEmail $email,
 		private PasswordHash $passwordHash,
-		private string $displayName,
+		private DisplayName $displayName,
 		private readonly DateTime $createdAt,
 		private DateTime $updatedAt,
 		private UserStatus $status = UserStatus::Inactive
@@ -80,7 +80,7 @@ final class User extends AggregateRoot
 	/**
 	 * Get the display name.
 	 */
-	public function getDisplayName(): string
+	public function getDisplayName(): DisplayName
 	{
 		return $this->displayName;
 	}
@@ -198,8 +198,12 @@ final class User extends AggregateRoot
 	/**
 	 * Change the display name of the user.
 	 */
-	public function changeDisplayName(string $displayName): void
+	public function changeDisplayName(DisplayName $displayName): void
 	{
+		if ($this->displayName->equals($displayName)) {
+			return;
+		}
+
 		$oldDisplayName    = $this->displayName;
 		$this->displayName = $displayName;
 		$this->updatedAt   = DateTime::now();
@@ -207,8 +211,8 @@ final class User extends AggregateRoot
 		$this->recordDomainEvent(
 			new UserDisplayNameWasChanged(
 				$this->id->toNative(),
-				$oldDisplayName,
-				$displayName,
+				$oldDisplayName->toNative(),
+				$displayName->toNative(),
 				$this->updatedAt->toNative()
 			)
 		);
@@ -221,7 +225,7 @@ final class User extends AggregateRoot
 		UserId $id,
 		UserEmail $email,
 		PasswordHash $password,
-		string $displayName
+		DisplayName $displayName
 	): self {
 		$user = new self(
 			$id,
@@ -237,6 +241,7 @@ final class User extends AggregateRoot
 			new UserWasRegistered(
 				$user->getId()->toNative(),
 				$user->getEmail()->toNative(),
+				$user->getDisplayName()->toNative(),
 				$user->getCreatedAt()->toNative()
 			)
 		);

--- a/src/User/Identity/Domain/Event/UserWasRegistered.php
+++ b/src/User/Identity/Domain/Event/UserWasRegistered.php
@@ -27,6 +27,7 @@ final readonly class UserWasRegistered implements DomainEventInterface
 	public function __construct(
 		public string $userId,
 		public string $email,
+		public string $displayName,
 		private DateTimeImmutable $createdAt
 	) {}
 

--- a/src/User/Identity/Domain/Exception/EmailMustBeUniqueException.php
+++ b/src/User/Identity/Domain/Exception/EmailMustBeUniqueException.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Exception;
+
+use DomainException;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Thrown when the email is not unique.
+ */
+final class EmailMustBeUniqueException extends DomainException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to create a EmailMustBeUniqueException for a specific user email.
+	 */
+	public static function create(string $email): EmailMustBeUniqueException
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.identity',
+				'email_must_be_unique',
+				['email' => $email]
+			),
+			sprintf('Email must be unique: %s.', $email)
+		);
+	}
+}

--- a/src/User/Identity/Domain/Exception/InvalidDisplayNameException.php
+++ b/src/User/Identity/Domain/Exception/InvalidDisplayNameException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Exception;
+
+use InvalidArgumentException;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Throws when an invalid user display name value is encountered.
+ */
+final class InvalidDisplayNameException extends InvalidArgumentException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to initiate an InvalidDisplayNameException with a default message.
+	 */
+	public static function create(int $minLength, int $maxLength): self
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.identity',
+				'invalid_display_name',
+				[
+					'min_length' => $minLength,
+					'max_length' => $maxLength,
+				]
+			),
+			sprintf('Invalid display name, allowed minimum and maximum length are: "%d-%d"', $minLength, $maxLength)
+		);
+	}
+}

--- a/src/User/Identity/Domain/Guard/EmailMustBeUnique.php
+++ b/src/User/Identity/Domain/Guard/EmailMustBeUnique.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Guard;
+
+use Webify\User\Identity\Domain\Exception\EmailMustBeUniqueException;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\ValueObject\UserEmail;
+
+/**
+ * Guard prevents against the user registration with existed registered email.
+ */
+final readonly class EmailMustBeUnique
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private UserRepositoryInterface $repository
+	) {}
+
+	/**
+	 * Guards against the registration of a user with an email that already exists.
+	 *
+	 * @throws EmailMustBeUniqueException
+	 */
+	public function guard(UserEmail $email): void
+	{
+		if ($this->repository->isExists($email)) {
+			throw EmailMustBeUniqueException::create((string) $email);
+		}
+	}
+}

--- a/src/User/Identity/Domain/Repository/UserRepositoryInterface.php
+++ b/src/User/Identity/Domain/Repository/UserRepositoryInterface.php
@@ -15,7 +15,7 @@ namespace Webify\User\Identity\Domain\Repository;
 
 use Webify\User\Identity\Domain\Entity\User;
 use Webify\User\Identity\Domain\Exception\UserNotFoundException;
-use Webify\User\Identity\Domain\ValueObject\UserId;
+use Webify\User\Identity\Domain\ValueObject\{UserEmail, UserId};
 
 /**
  * UserRepositoryInterface defines the contract for a user repository.
@@ -25,11 +25,21 @@ interface UserRepositoryInterface
 	/**
 	 * Retrieves an entity based on the provided unique UserId.
 	 *
-	 * @param UserId $id the unique identifier of the user to retrieve
-	 *
 	 * @throws UserNotFoundException if the user is not found
 	 */
 	public function getById(UserId $id): User;
+
+	/**
+	 * Retrieves an entity based on the provided unique UserEmail.
+	 *
+	 * @throws UserNotFoundException if the user is not found
+	 */
+	public function getByEmail(UserEmail $email): User;
+
+	/**
+	 * Checks if a user with the given email already exists.
+	 */
+	public function isExists(UserEmail $email): bool;
 
 	/**
 	 * Persists the given user entity to the underlying storage.

--- a/src/User/Identity/Domain/Service/RegisterUser.php
+++ b/src/User/Identity/Domain/Service/RegisterUser.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Service;
+
+use Webify\Base\Domain\Contract\Identity\PasswordHasherInterface;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\Service\UlidGeneratorInterface;
+use Webify\User\Identity\Domain\Entity\User;
+use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId};
+
+/**
+ * RegisterUser service handles the user registering process.
+ *
+ * Encapsulate the use case of registering a new user. Orchestrates email uniqueness validation,
+ * password hashing, user entity creation, persistence, and event publishing.
+ */
+final readonly class RegisterUser
+{
+	public function __construct(
+		private PasswordHasherInterface $passwordHasher,
+		private UserRepositoryInterface $repository,
+		private EmailMustBeUnique $emailMustBeUnique,
+		private UlidGeneratorInterface $ulidGenerator,
+		private DomainEventPublisherInterface $eventPublisher
+	) {}
+
+	/**
+	 * Registers a new user with the provided email and password.
+	 *
+	 * @param string $email       the email of the user to register
+	 * @param string $password    the password of the user to register
+	 * @param string $displayName the display name of the user to register
+	 */
+	public function register(string $email, string $password, string $displayName): void
+	{
+		$userEmail = UserEmail::fromString($email);
+
+		$this->emailMustBeUnique->guard($userEmail);
+
+		$hashedPassword = $this->passwordHasher->hash($password);
+		$user           = User::register(
+			UserId::fromString($this->ulidGenerator->generate()),
+			$userEmail,
+			PasswordHash::fromHash($hashedPassword),
+			DisplayName::fromString($displayName)
+		);
+
+		$this->repository->persist($user);
+		$this->eventPublisher->publish(...$user->getDomainEvents());
+	}
+}

--- a/src/User/Identity/Domain/ValueObject/DisplayName.php
+++ b/src/User/Identity/Domain/ValueObject/DisplayName.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\ValueObject;
+
+use Webify\User\Identity\Domain\Exception\InvalidDisplayNameException;
+
+/**
+ * DisplayName value object represents the display name of a user.
+ */
+final readonly class DisplayName
+{
+	/**
+	 * Allowed length.
+	 */
+	private const int MIN_LENGTH = 3;
+	private const int MAX_LENGTH = 255;
+
+	/**
+	 * Private constructor enforces the use of the factory method.
+	 *
+	 * @param string $value the display name value to be associated with the instance
+	 *
+	 * @throws InvalidDisplayNameException if the provided display name is invalid
+	 */
+	private function __construct(private string $value)
+	{
+		if (!$this->isValid()) {
+			throw InvalidDisplayNameException::create(self::MIN_LENGTH, self::MAX_LENGTH);
+		}
+	}
+
+	/**
+	 * Returns the string representation of the object.
+	 */
+	public function __toString(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Creates an instance of the class from the given string.
+	 */
+	public static function fromString(string $value): self
+	{
+		return new self(trim($value));
+	}
+
+	/**
+	 * Converts the object to its native string representation.
+	 */
+	public function toNative(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Determines if the current object is equal to the specified object.
+	 *
+	 * @param self $other the object to compare with the current object
+	 *
+	 * @return bool true if the objects are equal, false otherwise
+	 */
+	public function equals(self $other): bool
+	{
+		return $this->toNative() === $other->toNative();
+	}
+
+	/**
+	 * Determines if the current object state is valid.
+	 *
+	 * @return bool true if valid, false otherwise
+	 */
+	private function isValid(): bool
+	{
+		return '' !== $this->value
+			&& mb_strlen($this->value) >= self::MIN_LENGTH
+			&& mb_strlen($this->value) <= self::MAX_LENGTH;
+	}
+}

--- a/test/User/Identity/Domain/Entity/UserTest.php
+++ b/test/User/Identity/Domain/Entity/UserTest.php
@@ -16,7 +16,8 @@ namespace Webify\Test\User\Identity\Domain\Entity;
 use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
 use PHPUnit\Framework\TestCase;
 use Webify\User\Identity\Domain\Entity\User;
-use Webify\User\Identity\Domain\Event\{UserEmailWasChanged,
+use Webify\User\Identity\Domain\Event\{UserDisplayNameWasChanged,
+	UserEmailWasChanged,
 	UserPasswordWasChanged,
 	UserWasActivated,
 	UserWasDeactivated,
@@ -24,7 +25,7 @@ use Webify\User\Identity\Domain\Event\{UserEmailWasChanged,
 use Webify\User\Identity\Domain\Exception\{UserAlreadyActivatedException,
 	UserAlreadyDeactivatedException,
 	UserCannotBeDeactivatedException};
-use Webify\User\Identity\Domain\ValueObject\{PasswordHash, UserEmail, UserId};
+use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId};
 use Webify\User\Identity\Infrastructure\Service\PasswordHasher;
 
 /**
@@ -35,8 +36,10 @@ use Webify\User\Identity\Infrastructure\Service\PasswordHasher;
 #[CoversClass(User::class)]
 #[CoversMethod(User::class, 'activate')]
 #[CoversMethod(User::class, 'deactivate')]
+#[CoversMethod(User::class, 'changeDisplayName')]
 #[CoversMethod(User::class, 'changeEmail')]
 #[CoversMethod(User::class, 'changePassword')]
+#[CoversMethod(User::class, 'getDisplayName')]
 final class UserTest extends TestCase
 {
 	/**
@@ -59,7 +62,7 @@ final class UserTest extends TestCase
 			UserId::fromString('01ARZ3NDEKTSV4RRFFQ69G5FAV'),
 			UserEmail::fromString('test@example.com'),
 			PasswordHash::fromHash($this->passwordHasher->hash('password')),
-			'Test User'
+			DisplayName::fromString('Test User')
 		);
 	}
 
@@ -182,5 +185,37 @@ final class UserTest extends TestCase
 
 		$this->assertCount(2, $events);
 		$this->assertInstanceOf(UserPasswordWasChanged::class, $events[1]);
+	}
+
+	#[Test]
+	public function testGetDisplayName(): void
+	{
+		$this->assertSame('Test User', $this->user->getDisplayName()->toNative());
+	}
+
+	#[Test]
+	public function testChangeDisplayName(): void
+	{
+		$newDisplayName = DisplayName::fromString('New Display Name');
+
+		$this->user->changeDisplayName($newDisplayName);
+		$this->assertTrue($this->user->getDisplayName()->equals($newDisplayName));
+
+		$events = $this->user->getDomainEvents();
+
+		$this->assertCount(2, $events);
+		$this->assertInstanceOf(UserDisplayNameWasChanged::class, $events[1]);
+	}
+
+	#[Test]
+	public function testChangeDisplayNameWithSameNameDoesNotRecordEvent(): void
+	{
+		$events = $this->user->getDomainEvents();
+		$this->assertCount(1, $events);
+
+		$this->user->changeDisplayName(DisplayName::fromString('Test User'));
+
+		$events = $this->user->getDomainEvents();
+		$this->assertCount(1, $events);
 	}
 }

--- a/test/User/Identity/Domain/Service/RegisterUserTest.php
+++ b/test/User/Identity/Domain/Service/RegisterUserTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Identity\Domain\Service;
+
+use PHPUnit\Framework\Attributes\{AllowMockObjectsWithoutExpectations, CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Contract\Identity\PasswordHasherInterface;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\Base\Domain\Service\UlidGeneratorInterface;
+use Webify\User\Identity\Domain\Entity\User;
+use Webify\User\Identity\Domain\Exception\EmailMustBeUniqueException;
+use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\Service\RegisterUser;
+use Webify\User\Identity\Domain\ValueObject\UserEmail;
+
+/**
+ * RegisterUserTest tests the RegisterUser domain service.
+ *
+ * @internal
+ */
+#[CoversClass(RegisterUser::class)]
+#[CoversMethod(RegisterUser::class, 'register')]
+final class RegisterUserTest extends TestCase
+{
+	/**
+	 * Password hasher service instance.
+	 */
+	private MockObject&PasswordHasherInterface $passwordHasher;
+
+	/**
+	 * Repository instance.
+	 */
+	private MockObject&UserRepositoryInterface $repository;
+
+	/**
+	 * Ulid generator service instance.
+	 */
+	private MockObject&UlidGeneratorInterface $ulidGenerator;
+
+	/**
+	 * Domain event publisher service instance.
+	 */
+	private DomainEventPublisherInterface&MockObject $eventPublisher;
+
+	/**
+	 * The RegisterUser instance.
+	 */
+	private RegisterUser $registerUser;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		$this->passwordHasher = $this->createMock(PasswordHasherInterface::class);
+		$this->repository     = $this->createMock(UserRepositoryInterface::class);
+		$this->ulidGenerator  = $this->createMock(UlidGeneratorInterface::class);
+		$this->eventPublisher = $this->createMock(DomainEventPublisherInterface::class);
+
+		$this->registerUser = new RegisterUser(
+			$this->passwordHasher,
+			$this->repository,
+			new EmailMustBeUnique($this->repository),
+			$this->ulidGenerator,
+			$this->eventPublisher
+		);
+	}
+
+	/**
+	 * Tests the successful registration of a new user.
+	 */
+	#[Test]
+	public function testRegisterUserSuccessfully(): void
+	{
+		$email        = 'test@example.com';
+		$password     = 'password123';
+		$displayName  = 'Test User';
+		$generatedId  = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+		$hashedPass   = password_hash($password, PASSWORD_DEFAULT);
+
+		$this->repository
+			->expects($this->once())
+			->method('isExists')
+			->with($this->callback(
+				function (UserEmail $userEmail) use ($email): bool {
+					return $userEmail->toNative() === $email;
+				}
+			))
+			->willReturn(false)
+		;
+		$this->passwordHasher
+			->expects($this->once())
+			->method('hash')
+			->with($password)
+			->willReturn($hashedPass)
+		;
+		$this->ulidGenerator
+			->expects($this->once())
+			->method('generate')
+			->willReturn($generatedId)
+		;
+		$this->repository
+			->expects($this->once())
+			->method('persist')
+			->with($this->isInstanceOf(User::class))
+		;
+		$this->eventPublisher
+			->expects($this->once())
+			->method('publish')
+		;
+
+		$this->registerUser->register($email, $password, $displayName);
+	}
+
+	/**
+	 * Tests that registration throws an exception when the email already exists.
+	 */
+	#[Test]
+	#[AllowMockObjectsWithoutExpectations]
+	public function testRegisterThrowsExceptionWhenEmailAlreadyExists(): void
+	{
+		$email = 'existing@example.com';
+
+		$this->repository
+			->expects($this->once())
+			->method('isExists')
+			->with($this->callback(
+				function (UserEmail $userEmail) use ($email): bool {
+					return $userEmail->toNative() === $email;
+				}
+			))
+			->willReturn(true)
+		;
+		$this->expectException(EmailMustBeUniqueException::class);
+		$this->registerUser->register($email, 'password123', 'Test User');
+	}
+}

--- a/test/User/Identity/Domain/ValueObject/DisplayNameTest.php
+++ b/test/User/Identity/Domain/ValueObject/DisplayNameTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Identity\Domain\ValueObject;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Identity\Domain\Exception\InvalidDisplayNameException;
+use Webify\User\Identity\Domain\ValueObject\DisplayName;
+
+/**
+ * DisplayNameTest tests the functionality of the DisplayName value object.
+ *
+ * @internal
+ */
+#[CoversClass(DisplayName::class)]
+#[CoversMethod(DisplayName::class, 'fromString')]
+#[CoversMethod(DisplayName::class, 'equals')]
+#[CoversMethod(DisplayName::class, '__toString')]
+#[CoversMethod(DisplayName::class, 'toNative')]
+final class DisplayNameTest extends TestCase
+{
+	/**
+	 * Tests the creation of a valid display name from a string.
+	 */
+	#[Test]
+	public function testCreateValidDisplayName(): void
+	{
+		$displayName = DisplayName::fromString('Test User');
+
+		$this->assertInstanceOf(DisplayName::class, $displayName);
+		$this->assertSame('Test User', $displayName->toNative());
+	}
+
+	/**
+	 * Tests that the display name value is trimmed of whitespace during creation.
+	 */
+	#[Test]
+	public function testCreateDisplayNameTrimsValue(): void
+	{
+		$displayName = DisplayName::fromString('  Test User  ');
+
+		$this->assertSame('Test User', $displayName->toNative());
+	}
+
+	/**
+	 * Tests that creating a display name with fewer than the minimum allowed characters throws an exception.
+	 */
+	#[Test]
+	public function testDisplayNameTooShortThrowsException(): void
+	{
+		$this->expectException(InvalidDisplayNameException::class);
+		DisplayName::fromString('AB');
+	}
+
+	/**
+	 * Tests that creating a display name with more than the maximum allowed characters throws an exception.
+	 */
+	#[Test]
+	public function testDisplayNameTooLongThrowsException(): void
+	{
+		$this->expectException(InvalidDisplayNameException::class);
+		DisplayName::fromString(str_repeat('A', 256));
+	}
+
+	/**
+	 * Tests that creating a display name with an empty string throws an exception.
+	 */
+	#[Test]
+	public function testEmptyDisplayNameThrowsException(): void
+	{
+		$this->expectException(InvalidDisplayNameException::class);
+		DisplayName::fromString('');
+	}
+
+	/**
+	 * Tests that creating a display name with only whitespace characters throws an exception.
+	 */
+	#[Test]
+	public function testWhitespaceOnlyDisplayNameThrowsException(): void
+	{
+		$this->expectException(InvalidDisplayNameException::class);
+		DisplayName::fromString('   ');
+	}
+
+	/**
+	 * Tests the toNative method returns the string value.
+	 */
+	#[Test]
+	public function testToNativeReturnsStringValue(): void
+	{
+		$displayName = DisplayName::fromString('Test User');
+
+		$this->assertSame('Test User', $displayName->toNative());
+	}
+
+	/**
+	 * Tests the string representation of the display name.
+	 */
+	#[Test]
+	public function testStringRepresentation(): void
+	{
+		$displayName = DisplayName::fromString('Test User');
+
+		$this->assertSame('Test User', (string) $displayName);
+	}
+
+	/**
+	 * Tests that equals returns true for two display names with the same value.
+	 */
+	#[Test]
+	public function testEqualsReturnsTrueForSameValue(): void
+	{
+		$displayName1 = DisplayName::fromString('Test User');
+		$displayName2 = DisplayName::fromString('Test User');
+
+		$this->assertTrue($displayName1->equals($displayName2));
+	}
+
+	/**
+	 * Tests that equals returns false for two display names with different values.
+	 */
+	#[Test]
+	public function testEqualsReturnsFalseForDifferentValue(): void
+	{
+		$displayName1 = DisplayName::fromString('User One');
+		$displayName2 = DisplayName::fromString('User Two');
+
+		$this->assertFalse($displayName1->equals($displayName2));
+	}
+}


### PR DESCRIPTION
Implement user registration with display name validation and uniqueness checks

- Added DisplayName value object to encapsulate display name logic and validation.
- Introduced EmailMustBeUnique guard to prevent duplicate email registrations.
- Created RegisterUser service to handle user registration, including email uniqueness and password hashing.
- Updated User entity to use DisplayName instead of a string for display name.
- Added relevant exceptions for invalid display names and non-unique emails.
- Enhanced User and RegisterUser tests to cover new functionality.