### PR TITLE
Added `UpdateUserPassword` service

### DIFF
--- a/src/User/Identity/Domain/Exception/CurrentPasswordNotMatchedException.php
+++ b/src/User/Identity/Domain/Exception/CurrentPasswordNotMatchedException.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Exception;
+
+use DomainException;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Thrown when the user's current password is not matched.
+ */
+final class CurrentPasswordNotMatchedException extends DomainException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to create a CurrentPasswordNotMatchedException for a specific user email.
+	 */
+	public static function create(): CurrentPasswordNotMatchedException
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.identity',
+				'current_password_not_matched'
+			),
+			'Current password does not matched.'
+		);
+	}
+}

--- a/src/User/Identity/Domain/Service/UpdateUserPassword.php
+++ b/src/User/Identity/Domain/Service/UpdateUserPassword.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Service;
+
+use Webify\Base\Domain\Contract\Identity\PasswordHasherInterface;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\User\Identity\Domain\Exception\CurrentPasswordNotMatchedException;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\ValueObject\{PasswordHash, UserId};
+
+/**
+ * UpdateUserPassword service handles the user password update process.
+ *
+ * Encapsulate the use case of changing a user's password. Verifies the current password
+ * before updating, then hashes the new password, and delegates to the aggregate.
+ */
+final readonly class UpdateUserPassword
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private PasswordHasherInterface $passwordHasher,
+		private UserRepositoryInterface $repository,
+		private DomainEventPublisherInterface $eventPublisher
+	) {}
+
+	/**
+	 * Updates a user's password after verifying the current password.
+	 *
+	 * @param string $userId          the unique identifier of the user
+	 * @param string $currentPassword the user's current password for verification
+	 * @param string $newPassword     the new password to be set for the user
+	 *
+	 * @throws CurrentPasswordNotMatchedException if the current password does not match the stored one
+	 */
+	public function update(string $userId, string $currentPassword, string $newPassword): void
+	{
+		$user = $this->repository->getById(UserId::fromString($userId));
+
+		if (!$this->passwordHasher->verify($currentPassword, $user->getPasswordHash()->toNative())) {
+			throw CurrentPasswordNotMatchedException::create();
+		}
+
+		$passwordHash = PasswordHash::fromHash($this->passwordHasher->hash($newPassword));
+
+		$user->changePassword($passwordHash);
+		$this->repository->persist($user);
+		$this->eventPublisher->publish(...$user->getDomainEvents());
+	}
+}

--- a/test/User/Identity/Domain/Service/UpdateUserPasswordTest.php
+++ b/test/User/Identity/Domain/Service/UpdateUserPasswordTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Identity\Domain\Service;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Contract\Identity\PasswordHasherInterface;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\User\Identity\Domain\Entity\User;
+use Webify\User\Identity\Domain\Event\UserPasswordWasChanged;
+use Webify\User\Identity\Domain\Exception\CurrentPasswordNotMatchedException;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\Service\UpdateUserPassword;
+use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId};
+
+/**
+ * UpdateUserPasswordTest tests the UpdateUserPassword domain service.
+ *
+ * @internal
+ */
+#[CoversClass(UpdateUserPassword::class)]
+#[CoversMethod(UpdateUserPassword::class, 'update')]
+final class UpdateUserPasswordTest extends TestCase
+{
+	/**
+	 * Password hasher service instance.
+	 */
+	private MockObject&PasswordHasherInterface $passwordHasher;
+
+	/**
+	 * Repository instance.
+	 */
+	private MockObject&UserRepositoryInterface $repository;
+
+	/**
+	 * Domain event publisher service instance.
+	 */
+	private DomainEventPublisherInterface&MockObject $eventPublisher;
+
+	/**
+	 * The UpdateUserPassword instance.
+	 */
+	private UpdateUserPassword $updateUserPassword;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		$this->passwordHasher     = $this->createMock(PasswordHasherInterface::class);
+		$this->repository         = $this->createMock(UserRepositoryInterface::class);
+		$this->eventPublisher     = $this->createMock(DomainEventPublisherInterface::class);
+		$this->updateUserPassword = new UpdateUserPassword(
+			$this->passwordHasher,
+			$this->repository,
+			$this->eventPublisher
+		);
+	}
+
+	/**
+	 * Tests the successful update of a user's password.
+	 *
+	 * This method verifies the full password update flow:
+	 * - The user is retrieved from the repository using the provided user ID.
+	 * - The current password is verified against the stored password hash.
+	 * - The new password is hashed and applied to the user aggregate.
+	 * - The updated user is persisted back to the repository.
+	 * - A UserPasswordWasChanged domain event is published.
+	 */
+	#[Test]
+	public function testUpdateUserPasswordSuccessfully(): void
+	{
+		$userId              = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+		$currentPassword     = 'current_password';
+		$newPassword         = 'new_password';
+		$currentPasswordHash = 'current_password_hash';
+		$newPasswordHash     = 'new_password_hash';
+		$user                = $this->createUser($userId, $currentPasswordHash);
+
+		$this->repository
+			->expects($this->once())
+			->method('getById')
+			->with($this->callback(
+				function (UserId $providedUserId) use ($userId): bool {
+					return $providedUserId->toNative() === $userId;
+				}
+			))
+			->willReturn($user)
+		;
+		$this->passwordHasher
+			->expects($this->once())
+			->method('verify')
+			->with($currentPassword, $currentPasswordHash)
+			->willReturn(true)
+		;
+		$this->passwordHasher
+			->expects($this->once())
+			->method('hash')
+			->with($newPassword)
+			->willReturn($newPasswordHash)
+		;
+		$this->repository
+			->expects($this->once())
+			->method('persist')
+			->with($this->callback(
+				function (User $persistedUser) use ($user, $newPasswordHash): bool {
+					$this->assertSame($user, $persistedUser);
+					$this->assertSame($newPasswordHash, $persistedUser->getPasswordHash()->toNative());
+
+					return true;
+				}
+			))
+		;
+		$this->eventPublisher
+			->expects($this->once())
+			->method('publish')
+			->with($this->isInstanceOf(UserPasswordWasChanged::class))
+		;
+		$this->updateUserPassword->update($userId, $currentPassword, $newPassword);
+	}
+
+	/**
+	 * Tests that the update method throws an exception when the current password is invalid.
+	 *
+	 * The method verifies that the CurrentPasswordNotMatchedException is raised
+	 * before hashing the new password, persisting the user, or publishing events.
+	 */
+	#[Test]
+	public function testUpdateThrowsExceptionWhenCurrentPasswordIsInvalid(): void
+	{
+		$userId              = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+		$currentPassword     = 'wrong_current_password';
+		$currentPasswordHash = 'current_password_hash';
+		$user                = $this->createUser($userId, $currentPasswordHash);
+
+		$this->repository
+			->expects($this->once())
+			->method('getById')
+			->with($this->callback(
+				function (UserId $providedUserId) use ($userId): bool {
+					return $providedUserId->toNative() === $userId;
+				}
+			))
+			->willReturn($user)
+		;
+		$this->passwordHasher
+			->expects($this->once())
+			->method('verify')
+			->with($currentPassword, $currentPasswordHash)
+			->willReturn(false)
+		;
+		$this->passwordHasher
+			->expects($this->never())
+			->method('hash')
+		;
+		$this->repository
+			->expects($this->never())
+			->method('persist')
+		;
+		$this->eventPublisher
+			->expects($this->never())
+			->method('publish')
+		;
+		$this->expectException(CurrentPasswordNotMatchedException::class);
+		$this->updateUserPassword->update($userId, $currentPassword, 'new_password');
+	}
+
+	/**
+	 * Creates a user aggregate for password update tests.
+	 *
+	 * The registration event is released to represent a user already
+	 * loaded from persistence before the password update use case starts.
+	 */
+	private function createUser(string $userId, string $passwordHash): User
+	{
+		$user = User::register(
+			UserId::fromString($userId),
+			UserEmail::fromString('test@example.com'),
+			PasswordHash::fromHash($passwordHash),
+			DisplayName::fromString('Test User')
+		);
+
+		$user->releaseDomainEvents();
+
+		return $user;
+	}
+}


### PR DESCRIPTION
Added `UpdateUserPassword` service for secure password updates with tests:

- ntroduced `UpdateUserPassword` domain service to handle password update functionality, including current password verification and password hashing.
- Added `CurrentPasswordNotMatchedException` to handle invalid current password cases.
- Implemented comprehensive tests for `UpdateUserPassword`, ensuring proper validation, hashing, persistence, and event publishing.