### PR TITLE
Added `UpdateUserEmail` service

### DIFF
--- a/src/User/Identity/Domain/Exception/EmailMustBeUniqueException.php
+++ b/src/User/Identity/Domain/Exception/EmailMustBeUniqueException.php
@@ -35,7 +35,7 @@ final class EmailMustBeUniqueException extends DomainException implements Transl
 	}
 
 	/**
-	 * Factory method to create a EmailMustBeUniqueException for a specific user email.
+	 * Factory method to create an EmailMustBeUniqueException for a specific user email.
 	 */
 	public static function create(string $email): EmailMustBeUniqueException
 	{

--- a/src/User/Identity/Domain/Service/UpdateUserEmail.php
+++ b/src/User/Identity/Domain/Service/UpdateUserEmail.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Service;
+
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\ValueObject\{UserEmail, UserId};
+
+/**
+ * UpdateUserEmail service handles the user email update process.
+ *
+ * Encapsulate the use case of changing a user's email address. Validates that the new email
+ * is not already taken before updating.
+ */
+final readonly class UpdateUserEmail
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private EmailMustBeUnique $emailMustBeUnique,
+		private UserRepositoryInterface $repository,
+		private DomainEventPublisherInterface $eventPublisher
+	) {}
+
+	/**
+	 * Updates a user's password after verifying the current password.
+	 *
+	 * @param string $userId       the unique identifier of the user
+	 * @param string $newUserEmail the user's new email for change
+	 */
+	public function update(string $userId, string $newUserEmail): void
+	{
+		$user  = $this->repository->getById(UserId::fromString($userId));
+		$email = UserEmail::fromString($newUserEmail);
+
+		$this->emailMustBeUnique->guard($email);
+
+		$user->changeEmail($email);
+		$this->repository->persist($user);
+		$this->eventPublisher->publish(...$user->getDomainEvents());
+	}
+}

--- a/test/User/Identity/Domain/Service/UpdateUserEmailTest.php
+++ b/test/User/Identity/Domain/Service/UpdateUserEmailTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Identity\Domain\Service;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Event\DomainEventPublisherInterface;
+use Webify\User\Identity\Domain\Entity\User;
+use Webify\User\Identity\Domain\Event\UserEmailWasChanged;
+use Webify\User\Identity\Domain\Exception\EmailMustBeUniqueException;
+use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\Service\UpdateUserEmail;
+use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId};
+
+/**
+ * UpdateUserEmailTest tests the UpdateUserEmail domain service.
+ *
+ * @internal
+ */
+#[CoversClass(UpdateUserEmail::class)]
+#[CoversMethod(UpdateUserEmail::class, 'update')]
+final class UpdateUserEmailTest extends TestCase
+{
+	/**
+	 * Repository instance.
+	 */
+	private MockObject&UserRepositoryInterface $repository;
+
+	/**
+	 * Domain event publisher service instance.
+	 */
+	private DomainEventPublisherInterface&MockObject $eventPublisher;
+
+	/**
+	 * The UpdateUserEmail instance.
+	 */
+	private UpdateUserEmail $updateUserEmail;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		$this->repository      = $this->createMock(UserRepositoryInterface::class);
+		$this->eventPublisher  = $this->createMock(DomainEventPublisherInterface::class);
+		$this->updateUserEmail = new UpdateUserEmail(
+			new EmailMustBeUnique($this->repository),
+			$this->repository,
+			$this->eventPublisher
+		);
+	}
+
+	/**
+	 * Tests the successful update of a user's email address.
+	 *
+	 * This method verifies the full email update flow:
+	 * - The user is retrieved from the repository using the provided user ID.
+	 * - The new email is checked for uniqueness before the aggregate is changed.
+	 * - The updated user is persisted back to the repository.
+	 * - A UserEmailWasChanged domain event is published with the old and new email addresses.
+	 */
+	#[Test]
+	public function testUpdateUserEmailSuccessfully(): void
+	{
+		$userId       = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+		$currentEmail = 'test@example.com';
+		$newEmail     = 'newemail@example.com';
+		$user         = $this->createUser($userId, $currentEmail);
+
+		$this->repository
+			->expects($this->once())
+			->method('getById')
+			->with($this->callback(
+				function (UserId $providedUserId) use ($userId): bool {
+					return $providedUserId->toNative() === $userId;
+				}
+			))
+			->willReturn($user)
+		;
+		$this->repository
+			->expects($this->once())
+			->method('isExists')
+			->with($this->callback(
+				function (UserEmail $providedEmail) use ($newEmail): bool {
+					return $providedEmail->toNative() === $newEmail;
+				}
+			))
+			->willReturn(false)
+		;
+		$this->repository
+			->expects($this->once())
+			->method('persist')
+			->with($this->callback(
+				function (User $persistedUser) use ($user, $newEmail): bool {
+					$this->assertSame($user, $persistedUser);
+					$this->assertSame($newEmail, $persistedUser->getEmail()->toNative());
+
+					return true;
+				}
+			))
+		;
+		$this->eventPublisher
+			->expects($this->once())
+			->method('publish')
+			->with($this->callback(
+				function (UserEmailWasChanged $event) use ($userId, $currentEmail, $newEmail): bool {
+					$this->assertSame($userId, $event->userId);
+					$this->assertSame($currentEmail, $event->oldEmail);
+					$this->assertSame($newEmail, $event->newEmail);
+
+					return true;
+				}
+			))
+		;
+		$this->updateUserEmail->update($userId, $newEmail);
+	}
+
+	/**
+	 * Tests that the update method throws an exception when the new email already exists.
+	 *
+	 * The method verifies that the EmailMustBeUniqueException is raised before
+	 * persisting the user or publishing domain events.
+	 */
+	#[Test]
+	public function testUpdateThrowsExceptionWhenEmailAlreadyExists(): void
+	{
+		$userId      = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+		$newEmail    = 'existing@example.com';
+		$user        = $this->createUser($userId, 'test@example.com');
+
+		$this->repository
+			->expects($this->once())
+			->method('getById')
+			->with($this->callback(
+				function (UserId $providedUserId) use ($userId): bool {
+					return $providedUserId->toNative() === $userId;
+				}
+			))
+			->willReturn($user)
+		;
+		$this->repository
+			->expects($this->once())
+			->method('isExists')
+			->with($this->callback(
+				function (UserEmail $providedEmail) use ($newEmail): bool {
+					return $providedEmail->toNative() === $newEmail;
+				}
+			))
+			->willReturn(true)
+		;
+		$this->repository
+			->expects($this->never())
+			->method('persist')
+		;
+		$this->eventPublisher
+			->expects($this->never())
+			->method('publish')
+		;
+		$this->expectException(EmailMustBeUniqueException::class);
+		$this->updateUserEmail->update($userId, $newEmail);
+	}
+
+	/**
+	 * Creates a user aggregate for email update tests.
+	 *
+	 * The registration event is released to represent a user already
+	 * loaded from persistence before the email update use case starts.
+	 */
+	private function createUser(string $userId, string $email): User
+	{
+		$user = User::register(
+			UserId::fromString($userId),
+			UserEmail::fromString($email),
+			PasswordHash::fromHash('password_hash'),
+			DisplayName::fromString('Test User')
+		);
+
+		$user->releaseDomainEvents();
+
+		return $user;
+	}
+}


### PR DESCRIPTION
Added `UpdateUserEmail` service with tests for email updates and uniqueness validation

- Introduced `UpdateUserEmail` domain service to handle email update functionality, including email uniqueness checks and event publishing.
- Added unit tests for `UpdateUserEmail`, ensuring proper validation, persistence, and event publishing.