### PR TITLE
Added password strength validation guard

### DIFF
--- a/src/User/Identity/Domain/Exception/WeakPasswordException.php
+++ b/src/User/Identity/Domain/Exception/WeakPasswordException.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Exception;
+
+use DomainException;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Thrown when the user's current password is not strong enough.
+ */
+final class WeakPasswordException extends DomainException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Creates an exception indicating that the provided password is too short.
+	 *
+	 * @param int $minLength the minimum required length for the password
+	 */
+	public static function tooShort(int $minLength): self
+	{
+		return new self(
+			new ExceptionTranslation('user.identity', 'password_too_short', ['length' => $minLength]),
+			sprintf('Password must be at least %d characters long.', $minLength)
+		);
+	}
+
+	/**
+	 * Creates an exception for passwords that exceed the maximum allowed length.
+	 *
+	 * @param int $maxLength the maximum permitted length for the password
+	 */
+	public static function tooLong(int $maxLength): self
+	{
+		return new self(
+			new ExceptionTranslation('user.identity', 'password_too_long', ['length' => $maxLength]),
+			sprintf('Password must not exceed %d characters.', $maxLength)
+		);
+	}
+
+	/**
+	 * Creates an instance of this exception indicating that the password is missing an uppercase letter.
+	 */
+	public static function missingUppercase(): self
+	{
+		return new self(
+			new ExceptionTranslation('user.identity', 'password_missing_uppercase'),
+			'Password must contain at least one uppercase letter.'
+		);
+	}
+
+	/**
+	 * Creates an instance of this exception indicating that the password is missing an lowercase letter.
+	 */
+	public static function missingLowercase(): self
+	{
+		return new self(
+			new ExceptionTranslation('user.identity', 'password_missing_lowercase'),
+			'Password must contain at least one lowercase letter.'
+		);
+	}
+
+	/**
+	 * Creates an instance of this exception indicating that the password is missing a digit.
+	 */
+	public static function missingDigit(): self
+	{
+		return new self(
+			new ExceptionTranslation('user.identity', 'password_missing_digit'),
+			'Password must contain at least one digit.'
+		);
+	}
+
+	/**
+	 * Creates an instance of this exception indicating that the password is missing a special character.
+	 */
+	public static function missingSpecialChar(): self
+	{
+		return new self(
+			new ExceptionTranslation('user.identity', 'password_missing_special_char'),
+			'Password must contain at least one special character.'
+		);
+	}
+}

--- a/src/User/Identity/Domain/Guard/PasswordMustBeStrong.php
+++ b/src/User/Identity/Domain/Guard/PasswordMustBeStrong.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Guard;
+
+use Webify\User\Identity\Domain\Exception\WeakPasswordException;
+use Webify\User\Identity\Domain\Policy\PasswordPolicy;
+
+/**
+ * Guard prevents against the weak password.
+ */
+final readonly class PasswordMustBeStrong
+{
+	/**
+	 * The constructor.
+	 */
+	public function __construct(
+		private PasswordPolicy $policy
+	) {}
+
+	/**
+	 * Validates the provided password against the defined password policy.
+	 *
+	 * @param string $password the password to be validated
+	 *
+	 * @throws WeakPasswordException If the password does not meet the policy requirements:
+	 *                               - Too short
+	 *                               - Too long
+	 *                               - Missing uppercase character
+	 *                               - Missing lowercase character
+	 *                               - Missing digit
+	 *                               - Missing special character
+	 */
+	public function guard(string $password): void
+	{
+		$length = mb_strlen($password);
+
+		if (!$this->policy->isSatisfiedMinimumLength($length)) {
+			throw WeakPasswordException::tooShort($length);
+		}
+
+		if (!$this->policy->isSatisfiedMaximumLength($length)) {
+			throw WeakPasswordException::tooLong($length);
+		}
+
+		if (!$this->policy->isSatisfiedUppercase($password)) {
+			throw WeakPasswordException::missingUppercase();
+		}
+
+		if (!$this->policy->isSatisfiedLowercase($password)) {
+			throw WeakPasswordException::missingLowercase();
+		}
+
+		if (!$this->policy->isSatisfiedDigit($password)) {
+			throw WeakPasswordException::missingDigit();
+		}
+
+		if (!$this->policy->isSatisfiedSpecialCharacter($password)) {
+			throw WeakPasswordException::missingSpecialChar();
+		}
+	}
+}

--- a/src/User/Identity/Domain/Policy/PasswordPolicy.php
+++ b/src/User/Identity/Domain/Policy/PasswordPolicy.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Identity\Domain\Policy;
+
+/**
+ * Represents a password policy that validates passwords against specific criteria.
+ * This class defines rules such as minimum and maximum length, inclusion of uppercase
+ * and lowercase letters, digits, and special characters.
+ */
+final readonly class PasswordPolicy
+{
+	/**
+	 * The constructor.
+	 *
+	 * @param int $minimumLength         minimal length of the password
+	 * @param int $maximumLength         maximum length of the password
+	 * @param int $minimumUppercaseChars minimum number of uppercase characters in the password
+	 * @param int $minimumLowercaseChars minimum number of lowercase characters in the password
+	 * @param int $minimumDigits         minimum number of digits in the password
+	 * @param int $minimumSpecialChars   minimum number of special characters in the password
+	 */
+	public function __construct(
+		private int $minimumLength = 12,
+		private int $maximumLength = 128,
+		private int $minimumUppercaseChars = 2,
+		private int $minimumLowercaseChars = 2,
+		private int $minimumDigits = 1,
+		private int $minimumSpecialChars = 1
+	) {}
+
+	/**
+	 * Checks if the given length satisfies the minimum required length.
+	 *
+	 * @param int $length the length to be checked
+	 *
+	 * @return bool true if the length is greater than or equal to the minimum required length, false otherwise
+	 */
+	public function isSatisfiedMinimumLength(int $length): bool
+	{
+		return $this->minimumLength <= $length;
+	}
+
+	/**
+	 * Checks if the given length satisfies the maximum length constraint.
+	 *
+	 * @param int $length the length to be validated against the maximum allowed value
+	 *
+	 * @return bool returns true if the length is less than or equal to the maximum length, otherwise false
+	 */
+	public function isSatisfiedMaximumLength(int $length): bool
+	{
+		return $this->maximumLength >= $length;
+	}
+
+	/**
+	 * Checks if the given password contains at least one uppercase letter.
+	 *
+	 * @param string $password the password to be validated for an uppercase letter
+	 *
+	 * @return bool returns true if the password contains at least one uppercase letter, otherwise false
+	 */
+	public function isSatisfiedUppercase(string $password): bool
+	{
+		return preg_match_all('/[A-Z]/', $password) >= $this->minimumUppercaseChars;
+	}
+
+	/**
+	 * Determines if the given password contains at least one lowercase letter.
+	 *
+	 * @param string $password the password to check for the presence of lowercase letters
+	 *
+	 * @return bool returns true if the password contains one or more lowercase letters, otherwise false
+	 */
+	public function isSatisfiedLowercase(string $password): bool
+	{
+		return preg_match_all('/[a-z]/', $password) >= $this->minimumLowercaseChars;
+	}
+
+	/**
+	 * Determines if the given password contains at least one digit.
+	 *
+	 * @param string $password the password to be checked for the presence of a digit
+	 *
+	 * @return bool returns true if the password contains at least one digit, otherwise false
+	 */
+	public function isSatisfiedDigit(string $password): bool
+	{
+		return preg_match_all('/\d/', $password) >= $this->minimumDigits;
+	}
+
+	/**
+	 * Checks if the given password contains at least one special character.
+	 *
+	 * @param string $password the password to evaluate
+	 *
+	 * @return bool returns true if the password contains a special character, otherwise false
+	 */
+	public function isSatisfiedSpecialCharacter(string $password): bool
+	{
+		return preg_match_all('/[\W_]/', $password) >= $this->minimumSpecialChars;
+	}
+}

--- a/src/User/Identity/Domain/Service/RegisterUser.php
+++ b/src/User/Identity/Domain/Service/RegisterUser.php
@@ -17,7 +17,7 @@ use Webify\Base\Domain\Contract\Identity\PasswordHasherInterface;
 use Webify\Base\Domain\Event\DomainEventPublisherInterface;
 use Webify\Base\Domain\Service\UlidGeneratorInterface;
 use Webify\User\Identity\Domain\Entity\User;
-use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Guard\{EmailMustBeUnique, PasswordMustBeStrong};
 use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
 use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId};
 
@@ -29,10 +29,14 @@ use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmai
  */
 final readonly class RegisterUser
 {
+	/**
+	 * The constructor.
+	 */
 	public function __construct(
 		private PasswordHasherInterface $passwordHasher,
 		private UserRepositoryInterface $repository,
 		private EmailMustBeUnique $emailMustBeUnique,
+		private PasswordMustBeStrong $passwordMustBeStrong,
 		private UlidGeneratorInterface $ulidGenerator,
 		private DomainEventPublisherInterface $eventPublisher
 	) {}
@@ -49,6 +53,7 @@ final readonly class RegisterUser
 		$userEmail = UserEmail::fromString($email);
 
 		$this->emailMustBeUnique->guard($userEmail);
+		$this->passwordMustBeStrong->guard($password);
 
 		$hashedPassword = $this->passwordHasher->hash($password);
 		$user           = User::register(

--- a/src/User/Identity/Domain/Service/UpdateUserPassword.php
+++ b/src/User/Identity/Domain/Service/UpdateUserPassword.php
@@ -16,6 +16,7 @@ namespace Webify\User\Identity\Domain\Service;
 use Webify\Base\Domain\Contract\Identity\PasswordHasherInterface;
 use Webify\Base\Domain\Event\DomainEventPublisherInterface;
 use Webify\User\Identity\Domain\Exception\CurrentPasswordNotMatchedException;
+use Webify\User\Identity\Domain\Guard\PasswordMustBeStrong;
 use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
 use Webify\User\Identity\Domain\ValueObject\{PasswordHash, UserId};
 
@@ -33,6 +34,7 @@ final readonly class UpdateUserPassword
 	public function __construct(
 		private PasswordHasherInterface $passwordHasher,
 		private UserRepositoryInterface $repository,
+		private PasswordMustBeStrong $passwordMustBeStrong,
 		private DomainEventPublisherInterface $eventPublisher
 	) {}
 
@@ -52,6 +54,8 @@ final readonly class UpdateUserPassword
 		if (!$this->passwordHasher->verify($currentPassword, $user->getPasswordHash()->toNative())) {
 			throw CurrentPasswordNotMatchedException::create();
 		}
+
+		$this->passwordMustBeStrong->guard($newPassword);
 
 		$passwordHash = PasswordHash::fromHash($this->passwordHasher->hash($newPassword));
 

--- a/test/User/Identity/Domain/Guard/PasswordMustBeStrongTest.php
+++ b/test/User/Identity/Domain/Guard/PasswordMustBeStrongTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Identity\Domain\Guard;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Identity\Domain\Exception\WeakPasswordException;
+use Webify\User\Identity\Domain\Guard\PasswordMustBeStrong;
+use Webify\User\Identity\Domain\Policy\PasswordPolicy;
+
+/**
+ * PasswordMustBeStrongTest tests the PasswordMustBeStrong guard.
+ *
+ * @internal
+ */
+#[CoversClass(PasswordMustBeStrong::class)]
+#[CoversMethod(PasswordMustBeStrong::class, 'guard')]
+final class PasswordMustBeStrongTest extends TestCase
+{
+	/**
+	 * Tests that the guard passes when the password meets all policy requirements.
+	 */
+	#[Test]
+	public function testGuardPassesWhenPasswordSatisfiesAllRequirements(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectNotToPerformAssertions();
+		$guard->guard('StrongPass1!');
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the password is too short.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenPasswordIsTooShort(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectException(WeakPasswordException::class);
+		$guard->guard('Ab1!');
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the password exceeds the maximum length.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenPasswordIsTooLong(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectException(WeakPasswordException::class);
+		$guard->guard('A1!' . str_repeat('x', 130));
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the password has insufficient uppercase characters.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenMissingUppercase(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectException(WeakPasswordException::class);
+		$guard->guard('lowercase123!');
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the password has insufficient lowercase characters.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenMissingLowercase(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectException(WeakPasswordException::class);
+		$guard->guard('UPPERCASE12!');
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the password has no digits.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenMissingDigit(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectException(WeakPasswordException::class);
+		$guard->guard('UPPERlower!!');
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the password has no special characters.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenMissingSpecialCharacter(): void
+	{
+		$guard = new PasswordMustBeStrong(new PasswordPolicy());
+
+		$this->expectException(WeakPasswordException::class);
+		$guard->guard('UPPERlower12');
+	}
+}

--- a/test/User/Identity/Domain/Service/RegisterUserTest.php
+++ b/test/User/Identity/Domain/Service/RegisterUserTest.php
@@ -21,7 +21,8 @@ use Webify\Base\Domain\Event\DomainEventPublisherInterface;
 use Webify\Base\Domain\Service\UlidGeneratorInterface;
 use Webify\User\Identity\Domain\Entity\User;
 use Webify\User\Identity\Domain\Exception\EmailMustBeUniqueException;
-use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Guard\{EmailMustBeUnique, PasswordMustBeStrong};
+use Webify\User\Identity\Domain\Policy\PasswordPolicy;
 use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
 use Webify\User\Identity\Domain\Service\RegisterUser;
 use Webify\User\Identity\Domain\ValueObject\UserEmail;
@@ -74,6 +75,16 @@ final class RegisterUserTest extends TestCase
 			$this->passwordHasher,
 			$this->repository,
 			new EmailMustBeUnique($this->repository),
+			new PasswordMustBeStrong(
+				new PasswordPolicy(
+					minimumLength: 1,
+					maximumLength: 255,
+					minimumUppercaseChars: 0,
+					minimumLowercaseChars: 0,
+					minimumDigits: 0,
+					minimumSpecialChars: 0,
+				)
+			),
 			$this->ulidGenerator,
 			$this->eventPublisher
 		);

--- a/test/User/Identity/Domain/Service/UpdateUserPasswordTest.php
+++ b/test/User/Identity/Domain/Service/UpdateUserPasswordTest.php
@@ -21,6 +21,8 @@ use Webify\Base\Domain\Event\DomainEventPublisherInterface;
 use Webify\User\Identity\Domain\Entity\User;
 use Webify\User\Identity\Domain\Event\UserPasswordWasChanged;
 use Webify\User\Identity\Domain\Exception\CurrentPasswordNotMatchedException;
+use Webify\User\Identity\Domain\Guard\PasswordMustBeStrong;
+use Webify\User\Identity\Domain\Policy\PasswordPolicy;
 use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
 use Webify\User\Identity\Domain\Service\UpdateUserPassword;
 use Webify\User\Identity\Domain\ValueObject\{DisplayName, PasswordHash, UserEmail, UserId};
@@ -65,6 +67,16 @@ final class UpdateUserPasswordTest extends TestCase
 		$this->updateUserPassword = new UpdateUserPassword(
 			$this->passwordHasher,
 			$this->repository,
+			new PasswordMustBeStrong(
+				new PasswordPolicy(
+					minimumLength: 1,
+					maximumLength: 255,
+					minimumUppercaseChars: 0,
+					minimumLowercaseChars: 0,
+					minimumDigits: 0,
+					minimumSpecialChars: 0,
+				)
+			),
 			$this->eventPublisher
 		);
 	}


### PR DESCRIPTION
Added password strength validation guard and policy with implementation and tests

- Introduced `PasswordMustBeStrong` guard to enforce password strength rules during user registration and password updates.
- Added `PasswordPolicy` to define configurable criteria for password validation, including length, case sensitivity, digit, and special character requirements.
- Updated `RegisterUser` and `UpdateUserPassword` services to incorporate the new password strength validation.
- Created `WeakPasswordException` for handling violations of password strength rules.
- Implemented comprehensive unit tests for `PasswordMustBeStrong`, `PasswordPolicy`, and related exceptions to ensure robust validation behavior.