### PR TITLE
Added `ChallengeType` value object

### DIFF
--- a/src/User/Authentication/Domain/ValueObject/ChallengeType.php
+++ b/src/User/Authentication/Domain/ValueObject/ChallengeType.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\ValueObject;
+
+/**
+ * The challenge type value object.
+ *
+ * Enumerates the 2FA authentication challenge types the domain supports natively.
+ */
+enum ChallengeType: string
+{
+	case Code = 'code';
+	case Link = 'link';
+
+	/**
+	 * Determines if the current instance represents a Code.
+	 */
+	public function isCode(): bool
+	{
+		return self::Code === $this;
+	}
+
+	/**
+	 * Determines if the current instance represents a Link.
+	 */
+	public function isLink(): bool
+	{
+		return self::Link === $this;
+	}
+}

--- a/test/User/Authentication/Domain/ValueObject/ChallengeTypeTest.php
+++ b/test/User/Authentication/Domain/ValueObject/ChallengeTypeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authentication\Domain\ValueObject;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Authentication\Domain\ValueObject\ChallengeType;
+
+/**
+ * ChallengeTypeTest tests the functionality of the ChallengeType enum.
+ *
+ * @internal
+ */
+#[CoversClass(ChallengeType::class)]
+#[CoversMethod(ChallengeType::class, 'isCode')]
+#[CoversMethod(ChallengeType::class, 'isLink')]
+final class ChallengeTypeTest extends TestCase
+{
+	/**
+	 * Tests that the Code case has the correct backing value.
+	 */
+	#[Test]
+	public function testCodeCaseHasCorrectValue(): void
+	{
+		$this->assertSame('code', ChallengeType::Code->value);
+	}
+
+	/**
+	 * Tests that the Link case has the correct backing value.
+	 */
+	#[Test]
+	public function testLinkCaseHasCorrectValue(): void
+	{
+		$this->assertSame('link', ChallengeType::Link->value);
+	}
+
+	/**
+	 * Tests that isCode returns true for the Code case and false for the Link case.
+	 */
+	#[Test]
+	public function testIsCode(): void
+	{
+		$this->assertTrue(ChallengeType::Code->isCode());
+		$this->assertFalse(ChallengeType::Link->isCode());
+	}
+
+	/**
+	 * Tests that isLink returns true for the Link case and false for the Code case.
+	 */
+	#[Test]
+	public function testIsLink(): void
+	{
+		$this->assertTrue(ChallengeType::Link->isLink());
+		$this->assertFalse(ChallengeType::Code->isLink());
+	}
+
+	/**
+	 * Tests that tryFrom returns the correct case for a valid value.
+	 */
+	#[Test]
+	public function testTryFromWithValidValue(): void
+	{
+		$this->assertSame(ChallengeType::Code, ChallengeType::tryFrom('code'));
+		$this->assertSame(ChallengeType::Link, ChallengeType::tryFrom('link'));
+	}
+
+	/**
+	 * Tests that tryFrom returns null for an invalid value.
+	 */
+	#[Test]
+	public function testTryFromWithInvalidValue(): void
+	{
+		// @phpstan-ignore-next-line
+		$this->assertNull(ChallengeType::tryFrom('invalid'));
+	}
+}

--- a/test/User/Authorization/Domain/Guard/RoleAlreadyExistsTest.php
+++ b/test/User/Authorization/Domain/Guard/RoleAlreadyExistsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authorization\Domain\Guard;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Authorization\Domain\Exception\RoleAlreadyExistsException;
+use Webify\User\Authorization\Domain\Guard\RoleAlreadyExists;
+use Webify\User\Authorization\Domain\Repository\RoleRepositoryInterface;
+use Webify\User\Authorization\Domain\ValueObject\RoleSlug;
+
+/**
+ * RoleAlreadyExistsTest tests the functionality of the RoleAlreadyExists guard.
+ *
+ * @internal
+ */
+#[CoversClass(RoleAlreadyExists::class)]
+#[CoversMethod(RoleAlreadyExists::class, 'guard')]
+final class RoleAlreadyExistsTest extends TestCase
+{
+	/**
+	 * Tests that the guard passes when a role with the given slug does not exist.
+	 */
+	#[Test]
+	public function testGuardPassesWhenRoleDoesNotExist(): void
+	{
+		$slug       = RoleSlug::fromString('webify.admin');
+		$repository = $this->createMock(RoleRepositoryInterface::class);
+
+		$repository->expects($this->once())
+			->method('isExist')
+			->with($slug)
+			->willReturn(false)
+		;
+
+		$guard = new RoleAlreadyExists($repository);
+
+		$guard->guard($slug);
+	}
+
+	/**
+	 * Tests that the guard throws an exception when a role with the given slug already exists.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenRoleAlreadyExists(): void
+	{
+		$slug       = RoleSlug::fromString('webify.admin');
+		$repository = $this->createMock(RoleRepositoryInterface::class);
+
+		$repository->expects($this->once())
+			->method('isExist')
+			->with($slug)
+			->willReturn(true)
+		;
+
+		$guard = new RoleAlreadyExists($repository);
+
+		$this->expectException(RoleAlreadyExistsException::class);
+		$guard->guard($slug);
+	}
+}

--- a/test/User/Identity/Domain/Guard/EmailMustBeUniqueTest.php
+++ b/test/User/Identity/Domain/Guard/EmailMustBeUniqueTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Identity\Domain\Guard;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Identity\Domain\Exception\EmailMustBeUniqueException;
+use Webify\User\Identity\Domain\Guard\EmailMustBeUnique;
+use Webify\User\Identity\Domain\Repository\UserRepositoryInterface;
+use Webify\User\Identity\Domain\ValueObject\UserEmail;
+
+/**
+ * EmailMustBeUniqueTest tests the functionality of the EmailMustBeUnique guard.
+ *
+ * @internal
+ */
+#[CoversClass(EmailMustBeUnique::class)]
+#[CoversMethod(EmailMustBeUnique::class, 'guard')]
+final class EmailMustBeUniqueTest extends TestCase
+{
+	/**
+	 * Tests that the guard passes when the email does not exist in the repository.
+	 */
+	#[Test]
+	public function testGuardPassesWhenEmailIsUnique(): void
+	{
+		$email      = UserEmail::fromString('test@example.com');
+		$repository = $this->createMock(UserRepositoryInterface::class);
+
+		$repository->expects($this->once())
+			->method('isExists')
+			->with($email)
+			->willReturn(false)
+		;
+
+		$guard = new EmailMustBeUnique($repository);
+
+		$guard->guard($email);
+	}
+
+	/**
+	 * Tests that the guard throws an exception when the email already exists in the repository.
+	 */
+	#[Test]
+	public function testGuardThrowsExceptionWhenEmailIsNotUnique(): void
+	{
+		$email      = UserEmail::fromString('test@example.com');
+		$repository = $this->createMock(UserRepositoryInterface::class);
+
+		$repository->expects($this->once())
+			->method('isExists')
+			->with($email)
+			->willReturn(true)
+		;
+
+		$guard = new EmailMustBeUnique($repository);
+
+		$this->expectException(EmailMustBeUniqueException::class);
+		$guard->guard($email);
+	}
+}


### PR DESCRIPTION
Added `ChallengeType` value object and associated tests, along with guards for ensuring role and email uniqueness

- Introduced `ChallengeType` value object to represent 2FA challenge types, with helper methods for type checks (`isCode`, `isLink`).
- Added `ChallengeTypeTest` for unit testing value object functionality.
- Implemented `RoleAlreadyExists` guard to enforce unique role slugs during role creation, with accompanying tests.
- Added `EmailMustBeUnique` guard to validate email uniqueness during user identity operations, with unit tests ensuring coverage.