### PR TITLE
Added `ChallengeCode` and `ChallengeToken` value objects

### DIFF
--- a/src/Base/Domain/Exception/SecureTokenGenerationFailedException.php
+++ b/src/Base/Domain/Exception/SecureTokenGenerationFailedException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Base\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Exception thrown when an invalid access token is encountered.
+ */
+final class SecureTokenGenerationFailedException extends RuntimeException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 * @param Throwable            $previous    the previous throwable used for the exception chaining (optional)
+	 */
+	private function __construct(
+		public readonly Throwable $previous,
+		public readonly ExceptionTranslation $translation,
+		string $message = '',
+	) {
+		parent::__construct($message, 0, $previous);
+	}
+
+	/**
+	 * Factory method to initiate this with a default message.
+	 */
+	public static function create(Throwable $throwable): SecureTokenGenerationFailedException
+	{
+		return new self(
+			$throwable,
+			new ExceptionTranslation(
+				'user.base',
+				'secure_token_generation_failed',
+			),
+			'Unable to generate secure token.',
+		);
+	}
+}

--- a/src/Base/Domain/ValueObject/SecureToken.php
+++ b/src/Base/Domain/ValueObject/SecureToken.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Webify\Base\Domain\ValueObject;
 
+use Random\RandomException;
+use Webify\Base\Domain\Exception\SecureTokenGenerationFailedException;
+
 /**
  * The secure token value object base class.
  *
@@ -25,7 +28,12 @@ abstract readonly class SecureToken
 	/**
 	 * Minimum length of the access token.
 	 */
-	private const int MIN_LENGTH = 64;
+	protected const int MIN_LENGTH = 64;
+
+	/**
+	 * The length of the access token.
+	 */
+	protected const int LENGTH = 64;
 
 	/**
 	 * Private constructor enforces the use of the factory method.
@@ -64,12 +72,17 @@ abstract readonly class SecureToken
 
 	/**
 	 * Creates a new cryptographically random access token.
-	 *
 	 * Uses random_bytes() and bin2hex() to produce a 64-character hex token.
+	 *
+	 * @throws SecureTokenGenerationFailedException if the random bytes generation fails
 	 */
 	public static function generate(): static
 	{
-		return new static(bin2hex(random_bytes(32)));
+		try {
+			return new static(bin2hex(random_bytes(self::LENGTH / 2)));
+		} catch (RandomException $exception) {
+			throw SecureTokenGenerationFailedException::create($exception);
+		}
 	}
 
 	/**

--- a/src/User/Authentication/Domain/Exception/ChallengeCodeGenerationFailedException.php
+++ b/src/User/Authentication/Domain/Exception/ChallengeCodeGenerationFailedException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Exception thrown when an invalid access token is encountered.
+ */
+final class ChallengeCodeGenerationFailedException extends RuntimeException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 * @param Throwable            $previous    the previous throwable used for the exception chaining (optional)
+	 */
+	private function __construct(
+		public readonly Throwable $previous,
+		public readonly ExceptionTranslation $translation,
+		string $message = '',
+	) {
+		parent::__construct($message, 0, $previous);
+	}
+
+	/**
+	 * Factory method to initiate this with a default message.
+	 */
+	public static function create(Throwable $throwable): ChallengeCodeGenerationFailedException
+	{
+		return new self(
+			$throwable,
+			new ExceptionTranslation(
+				'user.authentication',
+				'challenge_code_generation_failed',
+			),
+			'Unable to generate authentication challenge code.',
+		);
+	}
+}

--- a/src/User/Authentication/Domain/Exception/InvalidChallengeCodeException.php
+++ b/src/User/Authentication/Domain/Exception/InvalidChallengeCodeException.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\Exception;
+
+use InvalidArgumentException;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Exception thrown when an invalid access token is encountered.
+ */
+final class InvalidChallengeCodeException extends InvalidArgumentException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to initiate this with a default message.
+	 */
+	public static function forInvalidCode(string $code): InvalidChallengeCodeException
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.authentication',
+				'invalid_challenge_code',
+				['code' => $code]
+			),
+			sprintf('The authentication challenge code "%s" is invalid.', $code)
+		);
+	}
+}

--- a/src/User/Authentication/Domain/Exception/InvalidChallengeTokenException.php
+++ b/src/User/Authentication/Domain/Exception/InvalidChallengeTokenException.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\Exception;
+
+use InvalidArgumentException;
+use Webify\Base\Domain\Contract\Translation\{ExceptionTranslation, TranslatableExceptionInterface};
+
+/**
+ * Exception thrown when an invalid access token is encountered.
+ */
+final class InvalidChallengeTokenException extends InvalidArgumentException implements TranslatableExceptionInterface
+{
+	/**
+	 * Private constructor enforces the use of the factory methods to initiate this exception.
+	 *
+	 * @param ExceptionTranslation $translation the translation object for this exception
+	 * @param string               $message     the exception message (optional)
+	 */
+	private function __construct(
+		public readonly ExceptionTranslation $translation,
+		string $message = ''
+	) {
+		parent::__construct($message);
+	}
+
+	/**
+	 * Factory method to initiate this with a default message.
+	 */
+	public static function forInvalidToken(string $token): InvalidChallengeTokenException
+	{
+		return new self(
+			new ExceptionTranslation(
+				'user.authentication',
+				'invalid_challenge_token',
+				['token' => $token]
+			),
+			sprintf('The authentication challenge token "%s" is invalid.', $token)
+		);
+	}
+}

--- a/src/User/Authentication/Domain/ValueObject/ChallengeCode.php
+++ b/src/User/Authentication/Domain/ValueObject/ChallengeCode.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\ValueObject;
+
+use Random\RandomException;
+use Webify\User\Authentication\Domain\Exception\{ChallengeCodeGenerationFailedException, InvalidChallengeCodeException};
+
+/**
+ * Challenge code value object.
+ *
+ * Represents a 6-digit numeric code used for authentication challenges.
+ */
+final readonly class ChallengeCode
+{
+	/**
+	 * The length of the challenge code.
+	 */
+	private const int LENGTH = 6;
+
+	/**
+	 * Private constructor enforces the use of the factory methods.
+	 * 1. Validates the provided value.
+	 * 2. Throws an exception if the value is invalid.
+	 */
+	private function __construct(
+		private string $value
+	) {
+		if (!$this->isValid()) {
+			throw InvalidChallengeCodeException::forInvalidCode($this->value);
+		}
+	}
+
+	/**
+	 * Converts the object into its string representation.
+	 */
+	public function __toString(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Creates an instance of the class from a native integer value.
+	 */
+	public static function fromNative(int $value): self
+	{
+		return new self(str_pad((string) $value, self::LENGTH, '0', STR_PAD_LEFT));
+	}
+
+	/**
+	 * Creates an instance of the class from a string representation.
+	 */
+	public static function fromString(string $value): self
+	{
+		return new self($value);
+	}
+
+	/**
+	 * Generates a new challenge code.
+	 */
+	public static function generate(): self
+	{
+		try {
+			$code = str_pad(
+				(string) random_int(0, 999999),
+				self::LENGTH,
+				'0',
+				STR_PAD_LEFT
+			);
+		} catch (RandomException $exception) {
+			throw ChallengeCodeGenerationFailedException::create($exception);
+		}
+
+		return new self($code);
+	}
+
+	/**
+	 * Checks if the current challenge code is equal to another challenge code.
+	 */
+	public function equals(self $other): bool
+	{
+		return $this->value === $other->value;
+	}
+
+	/**
+	 * Converts the object into its native string representation.
+	 */
+	public function toNative(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Validates the challenge code.
+	 */
+	private function isValid(): bool
+	{
+		if (strlen($this->value) !== self::LENGTH) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/User/Authentication/Domain/ValueObject/ChallengeToken.php
+++ b/src/User/Authentication/Domain/ValueObject/ChallengeToken.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\User\Authentication\Domain\ValueObject;
+
+use Webify\Base\Domain\ValueObject\SecureToken;
+use Webify\User\Authentication\Domain\Exception\InvalidChallengeTokenException;
+
+/**
+ * Challenge token value object.
+ */
+final readonly class ChallengeToken extends SecureToken
+{
+	/**
+	 * Throws an exception for an invalid challenge token.
+	 */
+	public function throwException(string $value): never
+	{
+		throw InvalidChallengeTokenException::forInvalidToken($value);
+	}
+}

--- a/src/User/Authentication/Domain/ValueObject/ChallengeType.php
+++ b/src/User/Authentication/Domain/ValueObject/ChallengeType.php
@@ -20,8 +20,8 @@ namespace Webify\User\Authentication\Domain\ValueObject;
  */
 enum ChallengeType: string
 {
-	case Code = 'code';
-	case Link = 'link';
+	case Code  = 'code';
+	case Token = 'token';
 
 	/**
 	 * Determines if the current instance represents a Code.
@@ -32,10 +32,10 @@ enum ChallengeType: string
 	}
 
 	/**
-	 * Determines if the current instance represents a Link.
+	 * Determines if the current instance represents a Token.
 	 */
-	public function isLink(): bool
+	public function isToken(): bool
 	{
-		return self::Link === $this;
+		return self::Token === $this;
 	}
 }

--- a/test/Base/Domain/ValueObject/SecureTokenTest.php
+++ b/test/Base/Domain/ValueObject/SecureTokenTest.php
@@ -16,6 +16,7 @@ namespace Webify\Test\Base\Domain\ValueObject;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test, UsesClass};
 use PHPUnit\Framework\TestCase;
+use Webify\Base\Domain\Exception\SecureTokenGenerationFailedException;
 use Webify\Base\Domain\ValueObject\SecureToken;
 use Webify\Test\Base\Domain\ValueObject\Example\ExampleSecureToken;
 
@@ -31,6 +32,7 @@ use Webify\Test\Base\Domain\ValueObject\Example\ExampleSecureToken;
 #[CoversMethod(SecureToken::class, 'equals')]
 #[CoversMethod(SecureToken::class, '__toString')]
 #[UsesClass(ExampleSecureToken::class)]
+#[UsesClass(SecureTokenGenerationFailedException::class)]
 final class SecureTokenTest extends TestCase
 {
 	/**
@@ -39,9 +41,12 @@ final class SecureTokenTest extends TestCase
 	#[Test]
 	public function testCreateValidSecureToken(): void
 	{
-		$token = $this->createConcreteSecureToken('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
-
-		$this->assertInstanceOf(SecureToken::class, $token);
+		$this->assertInstanceOf(
+			SecureToken::class,
+			$this->createConcreteSecureToken(
+				'0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+			)
+		);
 	}
 
 	/**
@@ -51,7 +56,6 @@ final class SecureTokenTest extends TestCase
 	public function testInvalidShortTokenThrowsException(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
-
 		$this->createConcreteSecureToken('too-short');
 	}
 
@@ -126,7 +130,7 @@ final class SecureTokenTest extends TestCase
 	}
 
 	/**
-	 * Test equals with same values.
+	 * Test equals with the same values.
 	 */
 	#[Test]
 	public function testEqualsWithSameValues(): void
@@ -144,8 +148,12 @@ final class SecureTokenTest extends TestCase
 	#[Test]
 	public function testEqualsWithDifferentValues(): void
 	{
-		$token1 = $this->createConcreteSecureToken('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
-		$token2 = $this->createConcreteSecureToken('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdee');
+		$token1 = $this->createConcreteSecureToken(
+			'0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+		);
+		$token2 = $this->createConcreteSecureToken(
+			'0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdee'
+		);
 
 		$this->assertFalse($token1->equals($token2));
 	}
@@ -156,7 +164,9 @@ final class SecureTokenTest extends TestCase
 	#[Test]
 	public function testFromStringReturnsCorrectType(): void
 	{
-		$token = ExampleSecureToken::fromString('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+		$token = ExampleSecureToken::fromString(
+			'0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+		);
 
 		$this->assertInstanceOf(ExampleSecureToken::class, $token);
 	}

--- a/test/User/Authentication/Domain/ValueObject/ChallengeCodeTest.php
+++ b/test/User/Authentication/Domain/ValueObject/ChallengeCodeTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authentication\Domain\ValueObject;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Authentication\Domain\Exception\InvalidChallengeCodeException;
+use Webify\User\Authentication\Domain\ValueObject\ChallengeCode;
+
+/**
+ * Tests for the ChallengeCode value object.
+ *
+ * @internal
+ */
+#[CoversClass(ChallengeCode::class)]
+#[CoversMethod(ChallengeCode::class, '__toString')]
+#[CoversMethod(ChallengeCode::class, 'fromNative')]
+#[CoversMethod(ChallengeCode::class, 'fromString')]
+#[CoversMethod(ChallengeCode::class, 'generate')]
+#[CoversMethod(ChallengeCode::class, 'toNative')]
+#[CoversMethod(ChallengeCode::class, 'equals')]
+final class ChallengeCodeTest extends TestCase
+{
+	/**
+	 * Test creating a valid challenge code from a native integer.
+	 */
+	#[Test]
+	public function testFromNativeWithValidCode(): void
+	{
+		$code = ChallengeCode::fromNative(123456);
+
+		$this->assertSame('123456', $code->toNative());
+	}
+
+	/**
+	 * Test creating a valid challenge code from a string.
+	 */
+	#[Test]
+	public function testFromStringWithValidCode(): void
+	{
+		$code = ChallengeCode::fromString('123456');
+
+		$this->assertSame('123456', $code->toNative());
+	}
+
+	/**
+	 * Test fromNative pads short integers to six digits.
+	 */
+	#[Test]
+	public function testFromNativePadsShortInteger(): void
+	{
+		$code = ChallengeCode::fromNative(123);
+
+		$this->assertSame('000123', $code->toNative());
+	}
+
+	/**
+	 * Test throws InvalidChallengeCodeException for a string with invalid length.
+	 */
+	#[Test]
+	public function testThrowsExceptionForStringWithInvalidLength(): void
+	{
+		$this->expectException(InvalidChallengeCodeException::class);
+		ChallengeCode::fromString('123');
+	}
+
+	/**
+	 * Test throws InvalidChallengeCodeException for an empty string.
+	 */
+	#[Test]
+	public function testThrowsExceptionForEmptyString(): void
+	{
+		$this->expectException(InvalidChallengeCodeException::class);
+		ChallengeCode::fromString('');
+	}
+
+	/**
+	 * Test creating a challenge code from a string with leading zeros.
+	 */
+	#[Test]
+	public function testFromStringPreservesLeadingZeros(): void
+	{
+		$code = ChallengeCode::fromString('001234');
+
+		$this->assertSame('001234', $code->toNative());
+		$this->assertSame(6, strlen($code->toNative()));
+	}
+
+	/**
+	 * Test generate returns a ChallengeCode instance.
+	 */
+	#[Test]
+	public function testGenerateReturnsChallengeCodeInstance(): void
+	{
+		$this->assertInstanceOf(ChallengeCode::class, ChallengeCode::generate());
+	}
+
+	/**
+	 * Test __toString returns the string representation of the code.
+	 */
+	#[Test]
+	public function testToStringReturnsStringRepresentation(): void
+	{
+		$code = ChallengeCode::fromNative(123456);
+
+		$this->assertSame('123456', (string) $code);
+	}
+
+	/**
+	 * Test equals returns true for two challenge codes with the same value.
+	 */
+	#[Test]
+	public function testEqualsReturnsTrueForSameValue(): void
+	{
+		$code1 = ChallengeCode::fromNative(123456);
+		$code2 = ChallengeCode::fromNative(123456);
+
+		$this->assertTrue($code1->equals($code2));
+	}
+
+	/**
+	 * Test equals returns false for two challenge codes with different values.
+	 */
+	#[Test]
+	public function testEqualsReturnsFalseForDifferentValues(): void
+	{
+		$code1 = ChallengeCode::generate();
+		$code2 = ChallengeCode::generate();
+
+		$this->assertFalse($code1->equals($code2));
+	}
+}

--- a/test/User/Authentication/Domain/ValueObject/ChallengeTokenTest.php
+++ b/test/User/Authentication/Domain/ValueObject/ChallengeTokenTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * The file is part of the "webifycms/domain", WebifyCMS extension package.
+ *
+ * @see https://webifycms.com/extension/domain
+ *
+ * @copyright Copyright (c) 2023 WebifyCMS
+ * @license https://webifycms.com/extension/domain/license
+ * @author Mohammed Shifreen <mshifreen@gmail.com>
+ */
+declare(strict_types=1);
+
+namespace Webify\Test\User\Authentication\Domain\ValueObject;
+
+use PHPUnit\Framework\Attributes\{CoversClass, CoversMethod, Test};
+use PHPUnit\Framework\TestCase;
+use Webify\User\Authentication\Domain\Exception\InvalidChallengeTokenException;
+use Webify\User\Authentication\Domain\ValueObject\ChallengeToken;
+
+/**
+ * Tests for the ChallengeToken value object.
+ *
+ * @internal
+ */
+#[CoversClass(ChallengeToken::class)]
+#[CoversMethod(ChallengeToken::class, '__toString')]
+#[CoversMethod(ChallengeToken::class, 'generate')]
+#[CoversMethod(ChallengeToken::class, 'throwException')]
+final class ChallengeTokenTest extends TestCase
+{
+	/**
+	 * Test creating a valid challenge token from a 64-character hex string.
+	 */
+	#[Test]
+	public function testFromStringWithValidToken(): void
+	{
+		$value = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+		$token = ChallengeToken::fromString($value);
+
+		$this->assertSame($value, $token->toNative());
+	}
+
+	/**
+	 * Test throws InvalidChallengeTokenException for a token shorter than 64 characters.
+	 */
+	#[Test]
+	public function testThrowsExceptionForTooShortToken(): void
+	{
+		$this->expectException(InvalidChallengeTokenException::class);
+		$this->expectExceptionMessage('The authentication challenge token "short" is invalid.');
+
+		ChallengeToken::fromString('short');
+	}
+
+	/**
+	 * Test generate always produces a challenge token with at least 64 characters.
+	 */
+	#[Test]
+	public function testGenerateProducesLongEnoughToken(): void
+	{
+		$token = ChallengeToken::generate();
+
+		$this->assertGreaterThanOrEqual(64, strlen($token->toNative()));
+	}
+
+	/**
+	 * Test generate returns a ChallengeToken instance.
+	 */
+	#[Test]
+	public function testGenerateReturnsChallengeTokenInstance(): void
+	{
+		$token = ChallengeToken::generate();
+
+		$this->assertInstanceOf(ChallengeToken::class, $token);
+	}
+
+	/**
+	 * Test fromString returns a ChallengeToken instance.
+	 */
+	#[Test]
+	public function testFromStringReturnsChallengeTokenInstance(): void
+	{
+		$token = ChallengeToken::fromString('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+
+		$this->assertInstanceOf(ChallengeToken::class, $token);
+	}
+
+	/**
+	 * Test __toString returns the token value.
+	 */
+	#[Test]
+	public function testToStringReturnsTokenValue(): void
+	{
+		$value = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+		$token = ChallengeToken::fromString($value);
+
+		$this->assertSame($value, (string) $token);
+	}
+
+	/**
+	 * Test equals returns true for two challenge tokens with the same value.
+	 */
+	#[Test]
+	public function testEqualsReturnsTrueForSameValue(): void
+	{
+		$value  = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+		$token1 = ChallengeToken::fromString($value);
+		$token2 = ChallengeToken::fromString($value);
+
+		$this->assertTrue($token1->equals($token2));
+	}
+
+	/**
+	 * Test equals returns false for two challenge tokens with different values.
+	 */
+	#[Test]
+	public function testEqualsReturnsFalseForDifferentValues(): void
+	{
+		$token1 = ChallengeToken::generate();
+		$token2 = ChallengeToken::generate();
+
+		$this->assertFalse($token1->equals($token2));
+	}
+}

--- a/test/User/Authentication/Domain/ValueObject/ChallengeTypeTest.php
+++ b/test/User/Authentication/Domain/ValueObject/ChallengeTypeTest.php
@@ -24,7 +24,7 @@ use Webify\User\Authentication\Domain\ValueObject\ChallengeType;
  */
 #[CoversClass(ChallengeType::class)]
 #[CoversMethod(ChallengeType::class, 'isCode')]
-#[CoversMethod(ChallengeType::class, 'isLink')]
+#[CoversMethod(ChallengeType::class, 'isToken')]
 final class ChallengeTypeTest extends TestCase
 {
 	/**
@@ -37,32 +37,32 @@ final class ChallengeTypeTest extends TestCase
 	}
 
 	/**
-	 * Tests that the Link case has the correct backing value.
+	 * Tests that the Token case has the correct backing value.
 	 */
 	#[Test]
-	public function testLinkCaseHasCorrectValue(): void
+	public function testTokenCaseHasCorrectValue(): void
 	{
-		$this->assertSame('link', ChallengeType::Link->value);
+		$this->assertSame('token', ChallengeType::Token->value);
 	}
 
 	/**
-	 * Tests that isCode returns true for the Code case and false for the Link case.
+	 * Tests that isCode returns true for the Code case and false for the Token case.
 	 */
 	#[Test]
 	public function testIsCode(): void
 	{
 		$this->assertTrue(ChallengeType::Code->isCode());
-		$this->assertFalse(ChallengeType::Link->isCode());
+		$this->assertFalse(ChallengeType::Token->isCode());
 	}
 
 	/**
-	 * Tests that isLink returns true for the Link case and false for the Code case.
+	 * Tests that isToken returns true for the Token case and false for the Code case.
 	 */
 	#[Test]
-	public function testIsLink(): void
+	public function testIsToken(): void
 	{
-		$this->assertTrue(ChallengeType::Link->isLink());
-		$this->assertFalse(ChallengeType::Code->isLink());
+		$this->assertTrue(ChallengeType::Token->isToken());
+		$this->assertFalse(ChallengeType::Code->isToken());
 	}
 
 	/**
@@ -72,7 +72,7 @@ final class ChallengeTypeTest extends TestCase
 	public function testTryFromWithValidValue(): void
 	{
 		$this->assertSame(ChallengeType::Code, ChallengeType::tryFrom('code'));
-		$this->assertSame(ChallengeType::Link, ChallengeType::tryFrom('link'));
+		$this->assertSame(ChallengeType::Token, ChallengeType::tryFrom('token'));
 	}
 
 	/**


### PR DESCRIPTION
Added `ChallengeCode` and `ChallengeToken` value objects with exception handling, tests, and factory methods for generation.

- Replaced `ChallengeType` value `Link` with `Token`, updated related methods and tests.
- Added `InvalidChallengeCodeException` and `InvalidChallengeTokenException` to handle validation errors.
- Introduced `ChallengeCode` for 6-digit numeric codes and `ChallengeToken` for 64-character secure tokens.
- Implemented `ChallengeCodeGenerationFailedException` and `SecureTokenGenerationFailedException` for generation failures.
- Added comprehensive unit tests for all new value objects and exceptions, ensuring validation, equality, and generation behaviours.